### PR TITLE
Fix for Missing Assets on gh-pages Deployment.

### DIFF
--- a/proto-app/package.json
+++ b/proto-app/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "A Glasswall template for CRA with a Glasswall NPM library pre-loaded. To enforce a consistent codebase and allow for our frontend styles to come together from pre-packaged NPM modules.",
   "main": "template.json",
+  "homepage": "https://filetrust.github.io/icap-management-ui/",
   "author": "glasswallsolutions",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
fixes #11 

The package.json file was missing the "homepage" property, this property sets the base_url, and without it, the server couldn't load any of the files from the build folder.

Tested and deployed using the gh-pages package. [commit](https://github.com/filetrust/icap-management-ui/commit/f1a85bbe38fa9d9be45bdc3acc786bc1789395e4)