### PR TITLE
Update globalStore-reducers.js to Fix a SonarCloud Bug

### DIFF
--- a/server/frontend/src/context/globalStore/globalStore-reducers.js
+++ b/server/frontend/src/context/globalStore/globalStore-reducers.js
@@ -70,16 +70,14 @@ const addFilterFromInput = (state, addedFilter) => {
 const removeFilterFromSelected = (state, removedFilter) => {
 	const updateCheckbox = [...state.fileFilter];
 
-	updateCheckbox.map((filter) => {
+	updateCheckbox.forEach((filter) => {
 		if (removedFilter.filter === filter.filterName) {
-			filter.checkboxList.map((checkbox) => {
+			filter.checkboxList.forEach((checkbox) => {
 				if (checkbox.id === removedFilter.id) {
 					checkbox.isChecked = false;
 				}
-				return null;
 			});
 		}
-		return null;
 	});
 
 	const updatedList = [...state.selectedFilters].filter(


### PR DESCRIPTION
The bug: 
![image](https://user-images.githubusercontent.com/16911902/97649285-db109380-1a4e-11eb-8840-ca82ebf16c13.png)


Solution was to replace map function and the null return with a forEach.