### PR TITLE
Create and use an unprivileged user when executing the service in the Docker container

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -12,3 +12,7 @@ RUN yarn install && yarn build
 # Run Server
 WORKDIR /usr/bin/icap-management-portal/server/
 CMD yarn start
+
+# Run the container as an unprivileged user
+# See https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#non-root-user
+USER node


### PR DESCRIPTION
This PR enables running the Docker container as non-root, following [Docker and Node.js Best Practices](https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#non-root-user).