### PR TITLE
Unit Tests for Policy - Draft Policy

### DIFF
--- a/server/src/business/services/PolicyManagementService/PolicyManagementService.test.ts
+++ b/server/src/business/services/PolicyManagementService/PolicyManagementService.test.ts
@@ -11,7 +11,6 @@ import policyExample from "../../../common/http/PolicyManagementApi/policyExampl
 
 let getPolicyByIdStub: SinonStub;
 let getPolicyStub: SinonStub;
-// let saveDraftPolicyStub: SinonStub;
 
 const setupGetPolicyTest = () => {
     const responseString = policyExample;
@@ -113,19 +112,105 @@ describe("PolicyManagementService", () => {
         });
     });
 
-    // TODO: Finish saveDraftPolicy test
-    // describe("saveDraftPolicy", () => {
-    //     const responseString = "OK";
+    describe("saveDraftPolicy", () => {
+        let saveDraftPolicyStub: SinonStub;
 
-    //     beforeEach(() => {
-    //         saveDraftPolicyStub = stub(PolicyManagementApi, "saveDraftPolicy")
-    //             .resolves();
-    //     });
+        const saveDraftPolicyUrl = "www.glasswall.com";
+        const draftPolicy = new Policy(
+            policyExample.id,
+            policyExample.policyType,
+            policyExample.published,
+            policyExample.lastEdited,
+            policyExample.created,
+            policyExample.ncfsPolicy,
+            policyExample.adaptionPolicy,
+            policyExample.updatedBy
+        );
+        const expectedHeaders = { "Content-Type": "application/json" };
 
-    //     afterEach(() => {
-    //         saveDraftPolicyStub.restore();
-    //     });
-    // });
+        beforeEach(() => {
+            saveDraftPolicyStub = stub(PolicyManagementApi, "saveDraftPolicy")
+                .resolves();
+        });
 
-    // TODO: Add test for publish draft
+        afterEach(() => {
+            saveDraftPolicyStub.restore();
+        });
+
+        it("called_PolicyManagementApi_saveDraftPolicy", async () => {
+            // Arrange
+            const spy = spyOn(PolicyManagementApi, "saveDraftPolicy");
+            const policyManagementService = new PolicyManagementService(logger);
+
+            // Act
+            await policyManagementService.saveDraftPolicy(
+                saveDraftPolicyUrl, draftPolicy);
+
+            // Assert
+            expect(spy).toHaveBeenCalled();
+            expect(spy).toBeCalledWith(saveDraftPolicyUrl, draftPolicy, expectedHeaders);
+        });
+    });
+
+    describe("publishPolicy", () => {
+        let publishPolicyStub: SinonStub;
+
+        const publishPolicyUrl = "www.glasswall.com";
+        const policyId = Guid.create();
+        const expectedHeaders = { "Content-Type": "application/json" };
+
+        beforeEach(() => {
+            publishPolicyStub = stub(PolicyManagementApi, "publishPolicy")
+                .resolves();
+        });
+
+        afterEach(() => {
+            publishPolicyStub.restore();
+        });
+
+        it("called_PolicyManagementApi_publishPolicy", async () => {
+            // Arrange
+            const spy = spyOn(PolicyManagementApi, "publishPolicy");
+            const policyManagementService = new PolicyManagementService(logger);
+
+            // Act
+            await policyManagementService.publishPolicy(
+                publishPolicyUrl, policyId);
+
+            // Assert
+            expect(spy).toHaveBeenCalled();
+            expect(spy).toBeCalledWith(publishPolicyUrl, policyId, expectedHeaders);
+        });
+    });
+
+    describe("deleteDraftPolicy", () => {
+        let deleteDraftPolicyStub: SinonStub;
+
+        const deleteDraftPolicyUrl = "www.glasswall.com";
+        const policyId = Guid.create();
+        const expectedHeaders = { "Content-Type": "application/json" };
+
+        beforeEach(() => {
+            deleteDraftPolicyStub = stub(PolicyManagementApi, "deleteDraftPolicy")
+                .resolves();
+        });
+
+        afterEach(() => {
+            deleteDraftPolicyStub.restore();
+        });
+
+        it("called_PolicyManagementApi_deleteDraftPolicy", async () => {
+            // Arrange
+            const spy = spyOn(PolicyManagementApi, "deleteDraftPolicy");
+            const policyManagementService = new PolicyManagementService(logger);
+
+            // Act
+            await policyManagementService.deleteDraftPolicy(
+                deleteDraftPolicyUrl, policyId);
+
+            // Assert
+            expect(spy).toHaveBeenCalled();
+            expect(spy).toBeCalledWith(deleteDraftPolicyUrl, policyId, expectedHeaders);
+        });
+    });
 });

--- a/server/src/common/http/PolicyManagementApi/PolicyManagementApi.test.ts
+++ b/server/src/common/http/PolicyManagementApi/PolicyManagementApi.test.ts
@@ -2,17 +2,20 @@ import PolicyManagementApi from "./PolicyManagementApi";
 import { stub, SinonStub } from "sinon";
 import fetch = require("node-fetch");
 import { Guid } from "guid-typescript";
+import { Policy } from "../../../common/models/PolicyManagementService/Policy/Policy";
+import policyExample from "./policyExample.json";
+import { syncBuiltinESMExports } from "module";
 
 let fetchStub: SinonStub;
 let fetchStubResult: any
 
 const expectFetch = (stubbedFetch: SinonStub,
     expectedUrl: string,
-    method: "GET" | "POST") => {
-        expect(stubbedFetch.getCalls()).toHaveLength(1);
-        expect(stubbedFetch.getCall(0).args).toHaveLength(2);
-        expect(stubbedFetch.getCall(0).args[0]).toEqual(expectedUrl);
-        expect(stubbedFetch.getCall(0).args[1].method).toEqual(method);
+    method: "GET" | "POST" | "PUT" | "DELETE") => {
+    expect(stubbedFetch.getCalls()).toHaveLength(1);
+    expect(stubbedFetch.getCall(0).args).toHaveLength(2);
+    expect(stubbedFetch.getCall(0).args[0]).toEqual(expectedUrl);
+    expect(stubbedFetch.getCall(0).args[1].method).toEqual(method);
 };
 
 describe("PolicyManagementApi", () => {
@@ -21,7 +24,6 @@ describe("PolicyManagementApi", () => {
             // Arrange
             const url = "www.glasswall.com";
             const policyId = Guid.create();
-            const expectedRequestUrl = `${url}?id=${policyId.toString()}`;
             let error: any;
 
             beforeEach(async () => {
@@ -49,10 +51,6 @@ describe("PolicyManagementApi", () => {
             it("response_with_status_text", () => {
                 expect(error).not.toBe(undefined);
                 expect(error).toEqual("Error");
-            });
-
-            it("called_fetch_using_GET", () => {
-                expectFetch(fetchStub, expectedRequestUrl, "GET");
             });
         });
 
@@ -124,10 +122,6 @@ describe("PolicyManagementApi", () => {
                 expect(error).not.toBe(undefined);
                 expect(error).toEqual("Error");
             });
-
-            it("called_fetch_using_GET", () => {
-                expectFetch(fetchStub, url, "GET");
-            });
         });
 
         describe("should_respond_with_response_json_if_OK", () => {
@@ -164,7 +158,135 @@ describe("PolicyManagementApi", () => {
         });
     });
 
-    // TODO: Add test for save draft
+    describe("saveDraftPolicy", () => {
+        describe("response_status_not_OK", () => {
+            // Arrange
+            const url = "www.glasswall.com";
+            let error: any;
 
-    // TODO: Add test for publish draft
+            const draftPolicy = new Policy(
+                policyExample.id,
+                policyExample.policyType,
+                policyExample.published,
+                policyExample.lastEdited,
+                policyExample.created,
+                policyExample.ncfsPolicy,
+                policyExample.adaptionPolicy,
+                policyExample.updatedBy
+            );
+
+            beforeEach(async () => {
+                fetchStubResult = {
+                    ok: false,
+                    statusText: "Error"
+                };
+
+                fetchStub = stub(fetch, "default").returns(fetchStubResult);
+
+                // Act
+                try {
+                    await PolicyManagementApi.saveDraftPolicy(url, draftPolicy);
+                }
+                catch (err) {
+                    error = err;
+                }
+            });
+
+            afterEach(() => {
+                fetchStub.restore();
+            });
+
+            // Assert
+            it("responds_with_status_text", () => {
+                expect(error).not.toBe(undefined);
+                expect(error).toEqual("Error");
+            });
+
+            it("called_fetch_using_PUT", () => {
+                expectFetch(fetchStub, url, "PUT");
+            });
+        });
+    });
+
+    describe("publishPolicy", () => {
+        describe("response_status_not_OK", () => {
+            // Arrange
+            const url = "www.glasswall.com";
+            const policyId = Guid.create();
+            const expectedRequestUrl = `${url}?id=${policyId.toString()}`;
+            let error: any;
+
+            beforeEach(async () => {
+                fetchStubResult = {
+                    ok: false,
+                    statusText: "Error"
+                };
+
+                fetchStub = stub(fetch, "default").returns(fetchStubResult);
+
+                // Act
+                try {
+                    await PolicyManagementApi.publishPolicy(url, policyId);
+                }
+                catch (err) {
+                    error = err;
+                }
+            });
+
+            afterEach(() => {
+                fetchStub.restore();
+            });
+
+            // Assert
+            it("responds_with_status_text", () => {
+                expect(error).not.toBe(undefined);
+                expect(error).toEqual("Error");
+            });
+
+            it("called_fetch_using_PUT", () => {
+                expectFetch(fetchStub, expectedRequestUrl, "PUT");
+            });
+        });
+    });
+
+    describe("deleteDraftPolicy", () => {
+        describe("response_status_not_OK", () => {
+            // Arrange
+            const url = "www.glasswall.com";
+            const policyId = Guid.create();
+            const expectedRequestUrl = `${url}?id=${policyId.toString()}`;
+            let error: any;
+
+            beforeEach(async () => {
+                fetchStubResult = {
+                    ok: false,
+                    statusText: "Error"
+                };
+
+                fetchStub = stub(fetch, "default").returns(fetchStubResult);
+
+                // Act
+                try {
+                    await PolicyManagementApi.deleteDraftPolicy(url, policyId);
+                }
+                catch (err) {
+                    error = err;
+                }
+            });
+
+            afterEach(() => {
+                fetchStub.restore();
+            });
+
+            // Assert
+            it("responds_with_status_text", () => {
+                expect(error).not.toBe(undefined);
+                expect(error).toEqual("Error");
+            });
+
+            it("called_fetch_using_DELETE", () => {
+                expectFetch(fetchStub, expectedRequestUrl, "DELETE");
+            });
+        });
+    });
 });

--- a/server/src/common/http/PolicyManagementApi/PolicyManagementApi.test.ts
+++ b/server/src/common/http/PolicyManagementApi/PolicyManagementApi.test.ts
@@ -4,7 +4,6 @@ import fetch = require("node-fetch");
 import { Guid } from "guid-typescript";
 import { Policy } from "../../../common/models/PolicyManagementService/Policy/Policy";
 import policyExample from "./policyExample.json";
-import { syncBuiltinESMExports } from "module";
 
 let fetchStub: SinonStub;
 let fetchStubResult: any

--- a/server/src/service/Routes/Policy/PolicyRoutes.test.ts
+++ b/server/src/service/Routes/Policy/PolicyRoutes.test.ts
@@ -189,8 +189,129 @@ describe("PolicyRoutes", () => {
             });
         });
 
-        // TODO: Add test for save draft
+        describe("put_/policy/draft", () => {
+            // Arrange
+            const expectedRequestUrl =
+                config.policy.policyManagementServiceBaseUrl +
+                config.policy.saveDraftPolicyPath;
 
-        // TODO: Add test for publish draft
+            beforeEach(() => {
+                policyManagementServiceStub = stub(
+                    policyRoutes.policyManagementService, "saveDraftPolicy")
+                    .resolves();
+            });
+
+            afterEach(() => {
+                policyManagementServiceStub.restore();
+            });
+
+            it("responds_with_200_OK", (done) => {
+                // Act
+                // Assert
+                request(app)
+                    .put("/policy/draft")
+                    .send(policyExample)
+                    .expect(200, done)
+            });
+
+            it("called_PolicyManagementService_saveDraftPolicy", (done) => {
+                // Arrange
+                const spy = spyOn(policyRoutes.policyManagementService, "saveDraftPolicy");
+
+                // Act
+                request(app)
+                    .put("/policy/draft")
+                    .send(policyExample)
+                    .expect(200, () => {
+                        // Assert
+                        expect(spy).toHaveBeenCalled();
+                        expect(spy).toBeCalledWith(expectedRequestUrl, policyExample);
+                        done();
+                    })
+            });
+        });
+
+        describe("put_/policy/publish", () => {
+            // Arrange
+            const expectedRequestUrl =
+                config.policy.policyManagementServiceBaseUrl +
+                config.policy.publishPolicyPath;
+            const policyId = Guid.create();
+
+            beforeEach(() => {
+                policyManagementServiceStub = stub(
+                    policyRoutes.policyManagementService, "publishPolicy")
+                    .resolves();
+            });
+
+            afterEach(() => {
+                policyManagementServiceStub.restore();
+            });
+
+            it("responds_with_200_OK", (done) => {
+                // Act
+                // Assert
+                request(app)
+                    .put("/policy/publish/" + policyId)
+                    .expect(200, done)
+            });
+
+            it("called_PolicyManagementService_publishDraftPolicy", (done) => {
+                // Arrange
+                const spy = spyOn(policyRoutes.policyManagementService, "publishPolicy");
+
+                // Act
+                request(app)
+                    .put("/policy/publish/" + policyId)
+                    .expect(200, () => {
+                        // Assert
+                        expect(spy).toHaveBeenCalled()
+                        expect(spy).toBeCalledWith(expectedRequestUrl, policyId);
+                        done();
+                    })
+            })
+        });
+
+        describe("delete_/policy/draft", () => {
+            // Arrange
+            const expectedRequestUrl =
+                config.policy.policyManagementServiceBaseUrl +
+                config.policy.deletePolicyPath;
+
+            const policyId = Guid.create();
+
+            beforeEach(() => {
+                policyManagementServiceStub = stub(
+                    policyRoutes.policyManagementService, "deleteDraftPolicy")
+                    .resolves();
+            });
+
+            afterEach(() => {
+                policyManagementServiceStub.restore();
+            });
+
+            it("responds_with_200_OK", (done) => {
+                // Act
+                // Assert
+                request(app)
+                    .delete("/policy/draft/" + policyId)
+                    .expect(200, done)
+            });
+
+            it("called_PolicyManagementService_deleteDraftPolicy", (done) => {
+                // Arrange
+                const spy = spyOn(policyRoutes.policyManagementService, "deleteDraftPolicy");
+
+                // Act
+                request(app)
+                    .delete("/policy/draft/" + policyId)
+                    .expect(200, () => {
+                        // Assert
+                        expect(spy).toHaveBeenCalled();
+                        expect(spy).toBeCalledWith(expectedRequestUrl, policyId);
+                        done();
+                    })
+            });
+        })
     });
 });


### PR DESCRIPTION
Unit tests cover the following:
PolicyManagementService
- saveDraftPolicy
- publishPolicy
- deleteDraftPolicy

PolicyManagementApi
- saveDraftPolicy
- publishPolicy
- deleteDraftPolicy

PolicyRoutes
- /policy/draft PUT
- /policy/publish PUT
- /policy/draft DELETE