### PR TITLE
Policy - Distribute Adaptation and NCFS Policy after Publish

### DIFF
--- a/server/frontend/src/context/policy/api/index.ts
+++ b/server/frontend/src/context/policy/api/index.ts
@@ -6,13 +6,13 @@ import { Guid } from "guid-typescript";
 export const getCurrentPolicy = async (): Promise<Policy> => {
     const response = await getPolicy(Routes.policyRoutes.getCurrentPolicyRoute);
 
-    return response as Policy;
+    return response;
 }
 
 export const getDraftPolicy = async (): Promise<Policy> => {
     const response = await getPolicy(Routes.policyRoutes.getDraftPolicyRoute);
 
-    return response as Policy;
+    return response;
 }
 
 export const saveDraftPolicy = async (policy: Policy): Promise<void> => {

--- a/server/src/business/services/PolicyManagementService/PolicyManagementService.test.ts
+++ b/server/src/business/services/PolicyManagementService/PolicyManagementService.test.ts
@@ -154,19 +154,21 @@ describe("PolicyManagementService", () => {
 
     describe("publishPolicy", () => {
         let publishPolicyStub: SinonStub;
+        let distributeAdaptationPolicyStub: SinonStub;
+        let distributeNcfsPolicyStub: SinonStub;
 
         const publishPolicyUrl = "www.glasswall.com";
+        const distributeAdaptationPolicyUrl = "www.glasswall.com/adaptation";
+        const distributeNcfsPolicyUrl = "www.glasswall.com/ncfs";
         const policyId = Guid.create();
         const expectedHeaders = { "Content-Type": "application/json" };
 
-        beforeEach(() => {
-            publishPolicyStub = stub(PolicyManagementApi, "publishPolicy")
-                .resolves();
-        });
-
-        afterEach(() => {
-            publishPolicyStub.restore();
-        });
+        publishPolicyStub = stub(PolicyManagementApi, "publishPolicy")
+            .resolves();
+        distributeAdaptationPolicyStub = stub(PolicyManagementApi, "distributeAdaptationPolicy")
+            .resolves();
+        distributeNcfsPolicyStub = stub(PolicyManagementApi, "distributeNcfsPolicy")
+            .resolves();
 
         it("called_PolicyManagementApi_publishPolicy", async () => {
             // Arrange
@@ -175,11 +177,39 @@ describe("PolicyManagementService", () => {
 
             // Act
             await policyManagementService.publishPolicy(
-                publishPolicyUrl, policyId);
+                publishPolicyUrl, distributeAdaptationPolicyUrl, distributeNcfsPolicyUrl, policyId);
 
             // Assert
             expect(spy).toHaveBeenCalled();
             expect(spy).toBeCalledWith(publishPolicyUrl, policyId, expectedHeaders);
+        });
+
+        it("called_PolicyManagementApi_distributeAdaptationPolicy", async () => {
+            // Arrange
+            const spy = spyOn(PolicyManagementApi, "distributeAdaptationPolicy");
+            const policyManagementService = new PolicyManagementService(logger);
+
+            // Act
+            await policyManagementService.publishPolicy(
+                publishPolicyUrl, distributeAdaptationPolicyUrl, distributeNcfsPolicyUrl, policyId);
+
+            // Assert
+            expect(spy).toHaveBeenCalled();
+            expect(spy).toBeCalledWith(distributeAdaptationPolicyUrl, expectedHeaders);
+        });
+
+        it("called_PolicyManagementApi_distributeNcfsPolicy", async () => {
+            // Arrange
+            const spy = spyOn(PolicyManagementApi, "distributeNcfsPolicy");
+            const policyManagementService = new PolicyManagementService(logger);
+
+            // Act
+            await policyManagementService.publishPolicy(
+                publishPolicyUrl, distributeAdaptationPolicyUrl, distributeNcfsPolicyUrl, policyId);
+
+            // Assert
+            expect(spy).toHaveBeenCalled();
+            expect(spy).toBeCalledWith(distributeNcfsPolicyUrl, expectedHeaders);
         });
     });
 

--- a/server/src/business/services/PolicyManagementService/PolicyManagementService.test.ts
+++ b/server/src/business/services/PolicyManagementService/PolicyManagementService.test.ts
@@ -153,21 +153,17 @@ describe("PolicyManagementService", () => {
     });
 
     describe("publishPolicy", () => {
-        let publishPolicyStub: SinonStub;
-        let distributeAdaptationPolicyStub: SinonStub;
-        let distributeNcfsPolicyStub: SinonStub;
-
         const publishPolicyUrl = "www.glasswall.com";
         const distributeAdaptationPolicyUrl = "www.glasswall.com/adaptation";
         const distributeNcfsPolicyUrl = "www.glasswall.com/ncfs";
         const policyId = Guid.create();
         const expectedHeaders = { "Content-Type": "application/json" };
 
-        publishPolicyStub = stub(PolicyManagementApi, "publishPolicy")
+        stub(PolicyManagementApi, "publishPolicy")
             .resolves();
-        distributeAdaptationPolicyStub = stub(PolicyManagementApi, "distributeAdaptationPolicy")
+        stub(PolicyManagementApi, "distributeAdaptationPolicy")
             .resolves();
-        distributeNcfsPolicyStub = stub(PolicyManagementApi, "distributeNcfsPolicy")
+        stub(PolicyManagementApi, "distributeNcfsPolicy")
             .resolves();
 
         it("called_PolicyManagementApi_publishPolicy", async () => {

--- a/server/src/business/services/PolicyManagementService/PolicyManagementService.ts
+++ b/server/src/business/services/PolicyManagementService/PolicyManagementService.ts
@@ -107,11 +107,18 @@ class PolicyManagementService implements IPolicyManagementService {
         }
     }
 
-    publishPolicy = async (publishPolicyUrl: string, policyId: Guid) => {
+    publishPolicy = async (publishPolicyUrl: string, distributeAdaptationPolicyUrl: string, distributeNcfsPolicyUrl: string, policyId: Guid) => {
+        const headers = { "Content-Type": "application/json" };
+
         try {
             this.logger.info(`Publishing Policy - PolicyId: ${policyId}`);
+            await PolicyManagementApi.publishPolicy(publishPolicyUrl, policyId, headers);
 
-            await PolicyManagementApi.publishPolicy(publishPolicyUrl, policyId, { "Content-Type": "application/json" });
+            this.logger.info(`Attempting to Distribute Adaptation Policy - PolicyId: ${policyId}`);
+            await PolicyManagementApi.distributeAdaptationPolicy(distributeAdaptationPolicyUrl, headers);
+
+            this.logger.info(`Attempting to Distribute NCFS Policy - PolicyId: ${policyId}`);
+            await PolicyManagementApi.distributeNcfsPolicy(distributeNcfsPolicyUrl, headers);
 
             this.logger.info(`Published Policy - PolicyId: ${policyId}`);
         }

--- a/server/src/common/http/PolicyManagementApi/PolicyManagementApi.test.ts
+++ b/server/src/common/http/PolicyManagementApi/PolicyManagementApi.test.ts
@@ -121,6 +121,10 @@ describe("PolicyManagementApi", () => {
                 expect(error).not.toBe(undefined);
                 expect(error).toEqual("Error");
             });
+
+            it("called_fetch_using_GET", () => {
+                expectFetch(fetchStub, url, "GET");
+            })
         });
 
         describe("should_respond_with_response_json_if_OK", () => {

--- a/server/src/common/http/PolicyManagementApi/PolicyManagementApi.test.ts
+++ b/server/src/common/http/PolicyManagementApi/PolicyManagementApi.test.ts
@@ -248,6 +248,84 @@ describe("PolicyManagementApi", () => {
         });
     });
 
+    describe("distributeAdaptationPolicy", () => {
+        describe("response_status_not_OK", () => {
+            // Arrange
+            const url = "www.glasswall.com";
+            let error: any;
+
+            beforeEach(async () => {
+                fetchStubResult = {
+                    ok: false,
+                    statusText: "Error"
+                };
+
+                fetchStub = stub(fetch, "default").returns(fetchStubResult);
+
+                // Act
+                try {
+                    await PolicyManagementApi.distributeAdaptationPolicy(url);
+                }
+                catch (err) {
+                    error = err;
+                }
+            });
+
+            afterEach(() => {
+                fetchStub.restore();
+            });
+
+            // Assert
+            it("responds_with_status_text", () => {
+                expect(error).not.toBe(undefined);
+                expect(error).toEqual("Error");
+            });
+
+            it("called_fetch_using_PUT", () => {
+                expectFetch(fetchStub, url, "PUT");
+            });
+        });
+    });
+
+    describe("distributeNcfsPolicy", () => {
+        describe("response_status_not_OK", () => {
+            // Arrange
+            const url = "www.glasswall.com";
+            let error: any;
+
+            beforeEach(async () => {
+                fetchStubResult = {
+                    ok: false,
+                    statusText: "Error"
+                };
+
+                fetchStub = stub(fetch, "default").returns(fetchStubResult);
+
+                // Act
+                try {
+                    await PolicyManagementApi.distributeNcfsPolicy(url);
+                }
+                catch (err) {
+                    error = err;
+                }
+            });
+
+            afterEach(() => {
+                fetchStub.restore();
+            });
+
+            // Assert
+            it("responds_with_status_text", () => {
+                expect(error).not.toBe(undefined);
+                expect(error).toEqual("Error");
+            });
+
+            it("called_fetch_using_PUT", () => {
+                expectFetch(fetchStub, url, "PUT");
+            });
+        });
+    });
+
     describe("deleteDraftPolicy", () => {
         describe("response_status_not_OK", () => {
             // Arrange

--- a/server/src/common/http/PolicyManagementApi/PolicyManagementApi.ts
+++ b/server/src/common/http/PolicyManagementApi/PolicyManagementApi.ts
@@ -31,7 +31,7 @@ export default class PolicyManagementApi {
         return response.text();
     }
 
-    static saveDraftPolicy = async(saveDraftPolicyUrl: string, draftPolicy: Policy, headers?: { [header: string]: string }): Promise<void> => {
+    static saveDraftPolicy = async (saveDraftPolicyUrl: string, draftPolicy: Policy, headers?: { [header: string]: string }): Promise<void> => {
         const response = await fetch(saveDraftPolicyUrl, {
             method: "PUT",
             body: JSON.stringify(draftPolicy),
@@ -43,7 +43,7 @@ export default class PolicyManagementApi {
         }
     }
 
-    static publishPolicy = async(publishPolicyUrl: string, policyId: Guid, headers?: { [header: string]: string }): Promise<void> => {
+    static publishPolicy = async (publishPolicyUrl: string, policyId: Guid, headers?: { [header: string]: string }): Promise<void> => {
         const url = `${publishPolicyUrl}?id=${policyId.toString()}`;
 
         const response = await fetch(url, {
@@ -56,7 +56,29 @@ export default class PolicyManagementApi {
         }
     }
 
-    static deleteDraftPolicy = async(deleteDraftPolicyUrl: string, policyId: Guid, headers?: { [header: string]: string }): Promise<void> => {
+    static distributeAdaptationPolicy = async (distributeAdaptationPolicyUrl: string, headers?: { [header: string]: string }): Promise<void> => {
+        const response = await fetch(distributeAdaptationPolicyUrl, {
+            method: "PUT",
+            headers
+        });
+
+        if (!response.ok) {
+            throw response.statusText;
+        }
+    }
+
+    static distributeNcfsPolicy = async (distributeNcfsPolicyUrl: string, headers?: { [header: string]: string }): Promise<void> => {
+        const response = await fetch(distributeNcfsPolicyUrl, {
+            method: "PUT",
+            headers
+        });
+
+        if (!response.ok) {
+            throw response.statusText;
+        }
+    }
+
+    static deleteDraftPolicy = async (deleteDraftPolicyUrl: string, policyId: Guid, headers?: { [header: string]: string }): Promise<void> => {
         const url = `${deleteDraftPolicyUrl}?id=${policyId.toString()}`;
 
         const response = await fetch(url, {

--- a/server/src/common/models/IConfig.ts
+++ b/server/src/common/models/IConfig.ts
@@ -14,6 +14,7 @@ export default interface IConfig {
         getCurrentPolicyPath: string;
         getPolicyHistoryPath: string;
         publishPolicyPath: string;
-        distributePolicyPath: string;
+        distributeAdaptionPolicyPath: string;
+        distributeNcfsPolicyPath: string;
     }
 }

--- a/server/src/common/services/IPolicyManagementService.ts
+++ b/server/src/common/services/IPolicyManagementService.ts
@@ -9,6 +9,6 @@ export default interface IPolicyManagementService {
     getCurrentPolicy: (getCurrentPolicyUrl: string) => Promise<Policy>,
     getDraftPolicy: (getDraftPolicyUrl: string) => Promise<Policy>,
     saveDraftPolicy: (saveDraftPolicyUrl: string, draftPolicy: Policy) => Promise<void>,
-    publishPolicy: (publishPolicyUrl: string, policyId: Guid) => Promise<void>,
+    publishPolicy: (publishPolicyUrl: string, distributeAdaptationPolicyUrl: string, distributeNcfsPolicy: string, policyId: Guid) => Promise<void>,
     deleteDraftPolicy: (deleteDraftPolicyUrl: string, policyId: Guid) => Promise<void>
 }

--- a/server/src/service/Config.ts
+++ b/server/src/service/Config.ts
@@ -16,7 +16,8 @@ const Config = () => {
             getCurrentPolicyPath: "/policy/current",
             getPolicyHistoryPath: "/policy/history",
             publishPolicyPath: "/policy/publish",
-            distributePolicyPath: "/policy/distribute"
+            distributeAdaptionPolicyPath: "/policy/current/distribute-adaption",
+            distributeNcfsPolicyPath: "/policy/current/distribute-ncfs"
         }
     };
 
@@ -35,7 +36,8 @@ const Config = () => {
             getCurrentPolicyPath: "/policy/current",
             getPolicyHistoryPath: "/policy/history",
             publishPolicyPath: "/policy/publish",
-            distributePolicyPath: "/policy/distribute"
+            distributeAdaptionPolicyPath: "/policy/current/distribute-adaption",
+            distributeNcfsPolicyPath: "/policy/current/distribute-ncfs"
         }
     };
 

--- a/server/src/service/Routes/Policy/PolicyRoutes.test.ts
+++ b/server/src/service/Routes/Policy/PolicyRoutes.test.ts
@@ -233,9 +233,18 @@ describe("PolicyRoutes", () => {
 
         describe("put_/policy/publish", () => {
             // Arrange
-            const expectedRequestUrl =
+            const expectedPublishUrl =
                 config.policy.policyManagementServiceBaseUrl +
                 config.policy.publishPolicyPath;
+
+            const expectedDistributeAdaptationUrl =
+                config.policy.policyManagementServiceBaseUrl +
+                config.policy.distributeAdaptionPolicyPath;
+
+            const expectedDistributeNcfsUrl =
+                config.policy.policyManagementServiceBaseUrl +
+                config.policy.distributeNcfsPolicyPath
+
             const policyId = Guid.create();
 
             beforeEach(() => {
@@ -256,7 +265,7 @@ describe("PolicyRoutes", () => {
                     .expect(200, done)
             });
 
-            it("called_PolicyManagementService_publishDraftPolicy", (done) => {
+            it("called_PolicyManagementService_publishPolicy", (done) => {
                 // Arrange
                 const spy = spyOn(policyRoutes.policyManagementService, "publishPolicy");
 
@@ -266,7 +275,8 @@ describe("PolicyRoutes", () => {
                     .expect(200, () => {
                         // Assert
                         expect(spy).toHaveBeenCalled()
-                        expect(spy).toBeCalledWith(expectedRequestUrl, policyId);
+                        expect(spy).toBeCalledWith(
+                            expectedPublishUrl, expectedDistributeAdaptationUrl, expectedDistributeNcfsUrl, policyId);
                         done();
                     })
             })

--- a/server/src/service/Routes/Policy/PolicyRoutes.ts
+++ b/server/src/service/Routes/Policy/PolicyRoutes.ts
@@ -14,7 +14,8 @@ class PolicyRoutes {
     getCurrentPolicyPath: string;
     getPolicyHistoryPath: string;
     publishPolicyPath: string;
-    distributePolicyPath: string;
+    distributeAdaptationPolicyPath: string;
+    distributeNcfsPolicyPath: string;
 
     policyManagementService: PolicyManagementService;
 
@@ -29,7 +30,8 @@ class PolicyRoutes {
         this.saveDraftPolicyPath = config.policy.saveDraftPolicyPath;
         this.getCurrentPolicyPath = config.policy.getCurrentPolicyPath;
         this.publishPolicyPath = config.policy.publishPolicyPath;
-        this.distributePolicyPath = config.policy.distributePolicyPath;
+        this.distributeAdaptationPolicyPath = config.policy.distributeAdaptionPolicyPath;
+        this.distributeNcfsPolicyPath = config.policy.distributeNcfsPolicyPath;
         this.policyManagementService = new PolicyManagementService(logger);
         this.app = app;
         this.logger = logger;
@@ -104,10 +106,13 @@ class PolicyRoutes {
 
         // Publish Policy
         this.app.put("/policy/publish/:policyId", async (req, res) => {
-            const requestUrl = this.policyManagementServiceBaseUrl + this.publishPolicyPath;
+            const publishUrl = this.policyManagementServiceBaseUrl + this.publishPolicyPath;
+            const distributeAdaptationUrl = this.policyManagementServiceBaseUrl + this.distributeAdaptationPolicyPath;
+            const distributeNcfsUrl = this.policyManagementServiceBaseUrl + this.distributeNcfsPolicyPath;
 
             try {
-                await this.policyManagementService.publishPolicy(requestUrl, Guid.parse(req.params.policyId));
+                await this.policyManagementService.publishPolicy(
+                    publishUrl, distributeAdaptationUrl, distributeNcfsUrl, Guid.parse(req.params.policyId));
 
                 res.sendStatus(200);
             }

--- a/server/src/service/TestConfig.ts
+++ b/server/src/service/TestConfig.ts
@@ -16,7 +16,8 @@ const TestConfig = () => {
             getCurrentPolicyPath: "/test",
             getPolicyHistoryPath: "/test",
             publishPolicyPath: "/test",
-            distributePolicyPath: "/test"
+            distributeAdaptionPolicyPath: "/test",
+            distributeNcfsPolicyPath: "/test"
         }
     }
 


### PR DESCRIPTION
## Features
- Added distributeAdaptationPolicy and distributeNcfsPolicy to PolicyManagementApi
- Clicking publish in the UI now chains the distribute calls after a successful publish

## Other Changes
- Updated Unit tests for PolicyRoutes, PolicyManagementService and PolicyManagementApi, and added new tests for the distribute methods
- Added new paths to IConfig for distributeAdaptationPolicy and distributeNcfsPolicy