### PR TITLE
Fix for Viewing a Previous Policy in Policy History 

### DIFF
--- a/server/frontend/src/views/Policy/History/HistoryInfo/HistoryInfo.tsx
+++ b/server/frontend/src/views/Policy/History/HistoryInfo/HistoryInfo.tsx
@@ -69,7 +69,7 @@ const HistoryInfo = (props: HistoryInfoProps) => {
 							<h2 className={classes.head}>Config for non-compliant files</h2>
 							<div className={classes.ncfsContainer}>
 								<RoutesForNonCompliantFiles
-									ncfsRoutingUrl={props.policy.adaptionPolicy.ncfsRoute.ncfsRoutingUrl}
+									ncfsRoutingUrl={props.policy.adaptionPolicy.ncfsRoute ? props.policy.adaptionPolicy.ncfsRoute.ncfsRoutingUrl : ""}
 									disabled />
 
 								<PolicyForNonCompliantFiles


### PR DESCRIPTION
The default current policy doesn't have an ncfs routing URL, this value being null wasn't accounted for until now.