### PR TITLE
Added CancellationTokens to Abort In-Progress Http Requests

### DIFF
--- a/server/frontend/package.json
+++ b/server/frontend/package.json
@@ -17,6 +17,7 @@
     "@types/react-router-dom": "^5.1.6",
     "@types/react-toast-notifications": "^2.4.0",
     "@types/react-transition-group": "^4.2.4",
+    "axios": "^0.21.0",
     "bootstrap": "^4.5.3",
     "bootstrap-daterangepicker": "^3.1.0",
     "chart.js": "^2.9.3",

--- a/server/frontend/package.json
+++ b/server/frontend/package.json
@@ -71,6 +71,7 @@
     ]
   },
   "devDependencies": {
+    "@types/axios": "^0.14.0",
     "@types/moment": "^2.13.0",
     "cross-env": "^7.0.2",
     "customize-cra": "^1.0.0",

--- a/server/frontend/src/context/policy/PolicyContext.tsx
+++ b/server/frontend/src/context/policy/PolicyContext.tsx
@@ -16,7 +16,7 @@ export type TPolicyState = {
 	policyHistory: PolicyHistory,
 	isPolicyChanged: boolean,
 	status: "LOADING" | "ERROR" | "LOADED",
-	policyError: ""
+	policyError: "",
 }
 
 export const PolicyContext = createContext<TPolicyState | null>(null);

--- a/server/frontend/src/context/policy/PolicyContext.tsx
+++ b/server/frontend/src/context/policy/PolicyContext.tsx
@@ -16,7 +16,7 @@ export type TPolicyState = {
 	policyHistory: PolicyHistory,
 	isPolicyChanged: boolean,
 	status: "LOADING" | "ERROR" | "LOADED",
-	policyError: "",
+	policyError: ""
 }
 
 export const PolicyContext = createContext<TPolicyState | null>(null);

--- a/server/frontend/src/context/policy/PolicyContext.tsx
+++ b/server/frontend/src/context/policy/PolicyContext.tsx
@@ -1,3 +1,4 @@
+import { CancelToken } from "axios";
 import { Guid } from "guid-typescript";
 import { createContext } from "react";
 import { Policy } from "../../../../src/common/models/PolicyManagementService/Policy/Policy";
@@ -12,7 +13,7 @@ export type TPolicyState = {
 	cancelDraftChanges: () => void,
 	publishPolicy: (policyId: Guid) => void,
 	deleteDraftPolicy: (policyId: Guid) => void,
-	loadPolicyHistory: () => void,
+	loadPolicyHistory: (cancellationToken: CancelToken) => void,
 	policyHistory: PolicyHistory,
 	isPolicyChanged: boolean,
 	status: "LOADING" | "ERROR" | "LOADED",

--- a/server/frontend/src/context/policy/PolicyState.tsx
+++ b/server/frontend/src/context/policy/PolicyState.tsx
@@ -22,7 +22,7 @@ interface InitialPolicyState {
 	policyHistory: PolicyHistory,
 	isPolicyChanged: boolean,
 	status: "LOADING" | "ERROR" | "LOADED",
-	policyError: "",
+	policyError: ""
 }
 
 export const PolicyState = (props: { children: React.ReactNode }) => {
@@ -36,7 +36,7 @@ export const PolicyState = (props: { children: React.ReactNode }) => {
 		policyHistory: null,
 		isPolicyChanged: false,
 		status: "LOADING",
-		policyError: "",
+		policyError: ""
 	}
 
 	const [policyState, dispatch] = useReducer(policyReducer, initialState);

--- a/server/frontend/src/context/policy/PolicyState.tsx
+++ b/server/frontend/src/context/policy/PolicyState.tsx
@@ -77,7 +77,7 @@ export const PolicyState = (props: { children: React.ReactNode }) => {
 
 		(async (): Promise<void> => {
 			try {
-				await saveDraftPolicy(policyState.newDraftPolicy);
+				await saveDraftPolicy(policyState.newDraftPolicy, cancellationTokenSource.token);
 				setDraftPolicy(policyState.newDraftPolicy);
 				setIsPolicyChanged(false);
 				status = "LOADED";
@@ -102,7 +102,7 @@ export const PolicyState = (props: { children: React.ReactNode }) => {
 
 		(async (): Promise<void> => {
 			try {
-				await publish(policyId);
+				await publish(policyId, cancellationTokenSource.token);
 
 				const currentPolicy = await getCurrentPolicy(cancellationTokenSource.token);
 				setCurrentPolicy(currentPolicy);
@@ -129,7 +129,7 @@ export const PolicyState = (props: { children: React.ReactNode }) => {
 
 		(async (): Promise<void> => {
 			try {
-				await deleteDraft(policyId);
+				await deleteDraft(policyId, cancellationTokenSource.token);
 
 				const currentPolicy = await getCurrentPolicy(cancellationTokenSource.token);
 				setCurrentPolicy(currentPolicy);
@@ -156,7 +156,7 @@ export const PolicyState = (props: { children: React.ReactNode }) => {
 
 		(async (): Promise<void> => {
 			try {
-				const policyHistory = await getPolicyHistory();
+				const policyHistory = await getPolicyHistory(cancellationTokenSource.token);
 				policyHistory.policies.sort((a: any, b: any) => {
 					return Date.parse(b.created) - Date.parse(a.created);
 				});
@@ -203,6 +203,8 @@ export const PolicyState = (props: { children: React.ReactNode }) => {
 				cancellationTokenSource.cancel();
 			}
 		}
+
+		// eslint-disable-next-line
 	}, []);
 
 	return (

--- a/server/frontend/src/context/policy/PolicyState.tsx
+++ b/server/frontend/src/context/policy/PolicyState.tsx
@@ -221,7 +221,7 @@ export const PolicyState = (props: { children: React.ReactNode }) => {
 			policyHistory: policyState.policyHistory,
 			isPolicyChanged: policyState.isPolicyChanged,
 			status: policyState.status,
-			policyError: policyState.policyError,
+			policyError: policyState.policyError
 		}}>
 			{ props.children}
 		</PolicyContext.Provider>

--- a/server/frontend/src/context/policy/api/helpers/getPolicy.ts
+++ b/server/frontend/src/context/policy/api/helpers/getPolicy.ts
@@ -1,17 +1,27 @@
+import axios, { CancelToken } from "axios";
 import { Policy } from "../../../../../../src/common/models/PolicyManagementService/Policy/Policy";
 
-export const getPolicy = async (baseUrl: string): Promise<Policy> => {
-    const response = await fetch(baseUrl, {
+export const getPolicy = async (baseUrl: string, cancellationToken: CancelToken): Promise<Policy> => {
+    const response = await axios(baseUrl, {
         method: "GET",
         headers: {
             "Accept": "*/*",
             "Content-Type": "application/json"
-        }
-    });
+        },
+        cancelToken: cancellationToken
+    })
 
-    if (!response.ok) {
+    // const response = await fetch(baseUrl, {
+    //     method: "GET",
+    //     headers: {
+    //         "Accept": "*/*",
+    //         "Content-Type": "application/json"
+    //     }
+    // });
+
+    if (response.statusText !== "OK") {
         throw response.statusText;
     }
 
-    return response.json();
+    return response.data;
 }

--- a/server/frontend/src/context/policy/api/helpers/getPolicy.ts
+++ b/server/frontend/src/context/policy/api/helpers/getPolicy.ts
@@ -9,15 +9,7 @@ export const getPolicy = async (baseUrl: string, cancellationToken: CancelToken)
             "Content-Type": "application/json"
         },
         cancelToken: cancellationToken
-    })
-
-    // const response = await fetch(baseUrl, {
-    //     method: "GET",
-    //     headers: {
-    //         "Accept": "*/*",
-    //         "Content-Type": "application/json"
-    //     }
-    // });
+    });
 
     if (response.statusText !== "OK") {
         throw response.statusText;

--- a/server/frontend/src/context/policy/api/helpers/getPolicyById.ts
+++ b/server/frontend/src/context/policy/api/helpers/getPolicyById.ts
@@ -1,19 +1,22 @@
+import axios, { CancelToken } from "axios";
 import { Guid } from "guid-typescript";
+import { Policy } from "../../../../../../src/common/models/PolicyManagementService/Policy/Policy";
 
-export const getPolicyById = async (baseUrl: string, policyId: Guid): Promise<string> => {
+export const getPolicyById = async (baseUrl: string, policyId: Guid, cancellationToken: CancelToken): Promise<Policy> => {
     const url = `${baseUrl}/${policyId}`;
 
-    const response = await fetch(url, {
+    const response = await axios(url, {
         method: "GET",
         headers: {
             "Accept": "*/*",
             "Content-Type": "application/json"
-        }
+        },
+        cancelToken: cancellationToken
     });
 
-    if (!response.ok) {
+    if (response.statusText !== "OK") {
         throw response.statusText;
     }
 
-    return response.text();
+    return response.data;
 }

--- a/server/frontend/src/context/policy/api/index.ts
+++ b/server/frontend/src/context/policy/api/index.ts
@@ -17,67 +17,71 @@ export const getDraftPolicy = async (cancellationToken: CancelToken): Promise<Po
     return response;
 }
 
-export const saveDraftPolicy = async (policy: Policy): Promise<void> => {
-    const response = await fetch(Routes.policyRoutes.saveDraftPolicyRoute, {
+export const saveDraftPolicy = async (policy: Policy, cancellationToken: CancelToken): Promise<void> => {
+    const response = await axios(Routes.policyRoutes.saveDraftPolicyRoute, {
         method: "PUT",
         headers: {
             "Accept": "*/*",
             "Content-Type": "application/json"
         },
-        body: JSON.stringify(policy)
+        data: JSON.stringify(policy),
+        cancelToken: cancellationToken
     });
 
-    if (!response.ok) {
+    if (response.statusText !== "OK") {
         throw response.statusText;
     }
 }
 
-export const publishPolicy = async (policyId: Guid): Promise<void> => {
+export const publishPolicy = async (policyId: Guid, cancellationToken: CancelToken): Promise<void> => {
     const url = `${Routes.policyRoutes.publishPolicyRoute}/${policyId.toString()}`;
 
-    const response = await fetch(url, {
+    const response = await axios(url, {
         method: "PUT",
         headers: {
             "Accept": "*/*",
             "Content-Type": "application/json"
         },
+        cancelToken: cancellationToken
     });
 
-    if (!response.ok) {
+    if (response.statusText !== "OK") {
         throw response.statusText;
     }
 }
 
-export const deleteDraftPolicy = async (policyId: Guid): Promise<void> => {
+export const deleteDraftPolicy = async (policyId: Guid, cancellationToken: CancelToken): Promise<void> => {
     const url = `${Routes.policyRoutes.deletePolicyRoute}/${policyId.toString()}`;
 
-    const response = await fetch(url, {
+    const response = await axios(url, {
         method: "DELETE",
         headers: {
             "Accept": "*/*",
             "Content-Type": "application/json"
         },
+        cancelToken: cancellationToken
     });
 
-    if (!response.ok) {
+    if (response.statusText !== "OK") {
         throw response.statusText;
     }
 }
 
-export const getPolicyHistory = async (): Promise<PolicyHistory> => {
+export const getPolicyHistory = async (cancellationToken: CancelToken): Promise<PolicyHistory> => {
     const url = Routes.policyRoutes.getPolicyHistory;
 
-    const response = await fetch(url, {
+    const response = await axios(url, {
         method: "GET",
         headers: {
             "Accept": "*/*",
             "Content-Type": "application/json"
-        }
+        },
+        cancelToken: cancellationToken
     });
 
-    if (!response.ok) {
+    if (response.statusText !== "OK") {
         throw response.statusText;
     }
 
-    return response.json();
+    return response.data;
 }

--- a/server/frontend/src/context/policy/api/index.ts
+++ b/server/frontend/src/context/policy/api/index.ts
@@ -5,16 +5,14 @@ import Routes from "../../../Routes";
 import { Guid } from "guid-typescript";
 import { PolicyHistory } from "../../../../../src/common/models/PolicyManagementService/PolicyHistory/PolicyHistory";
 
-let cancel: CancelToken;
-
-export const getCurrentPolicy = async (): Promise<Policy> => {
-    const response = await getPolicy(Routes.policyRoutes.getCurrentPolicyRoute);
+export const getCurrentPolicy = async (cancellationToken: CancelToken): Promise<Policy> => {
+    const response = await getPolicy(Routes.policyRoutes.getCurrentPolicyRoute, cancellationToken);
 
     return response;
 }
 
-export const getDraftPolicy = async (): Promise<Policy> => {
-    const response = await getPolicy(Routes.policyRoutes.getDraftPolicyRoute);
+export const getDraftPolicy = async (cancellationToken: CancelToken): Promise<Policy> => {
+    const response = await getPolicy(Routes.policyRoutes.getDraftPolicyRoute, cancellationToken);
 
     return response;
 }

--- a/server/frontend/src/context/policy/api/index.ts
+++ b/server/frontend/src/context/policy/api/index.ts
@@ -1,8 +1,11 @@
+import axios, { CancelToken } from "axios";
 import { getPolicy } from "./helpers";
 import { Policy } from "../../../../../src/common/models/PolicyManagementService/Policy/Policy";
 import Routes from "../../../Routes";
 import { Guid } from "guid-typescript";
 import { PolicyHistory } from "../../../../../src/common/models/PolicyManagementService/PolicyHistory/PolicyHistory";
+
+let cancel: CancelToken;
 
 export const getCurrentPolicy = async (): Promise<Policy> => {
     const response = await getPolicy(Routes.policyRoutes.getCurrentPolicyRoute);

--- a/server/frontend/src/views/Policy/History/History.tsx
+++ b/server/frontend/src/views/Policy/History/History.tsx
@@ -1,4 +1,5 @@
 import React, { useContext, useState, useEffect } from "react";
+import axios from "axios";
 import { CSSTransition } from "react-transition-group";
 import {
 	Table,
@@ -20,6 +21,9 @@ import classes from "./History.module.scss";
 import { PolicyType } from "../../../../../src/common/models/enums/PolicyType";
 
 const History = () => {
+	const CancelToken = axios.CancelToken;
+	const cancellationTokenSource = CancelToken.source();
+
 	const {
 		status,
 		policyHistory,
@@ -43,7 +47,11 @@ const History = () => {
 	};
 
 	useEffect(() => {
-		loadPolicyHistory();
+		loadPolicyHistory(cancellationTokenSource.token);
+
+		return () => {
+			cancellationTokenSource.cancel();
+		}
 		// eslint-disable-next-line
 	}, []);
 

--- a/server/frontend/src/views/RequestHistory/FileInfo/FileInfo.tsx
+++ b/server/frontend/src/views/RequestHistory/FileInfo/FileInfo.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { CancelToken } from "axios";
+import axios from "axios";
 import {
 	Table,
 	TableHead,
@@ -27,10 +27,12 @@ interface FileData {
 
 export interface FileInfoProps {
 	fileData: FileData,
-	cancellationToken: CancelToken
 }
 
 const FileInfo = (props: FileInfoProps) => {
+	const CancelToken = axios.CancelToken;
+	const cancellationTokenSource = CancelToken.source();
+
 	const [transactionDetails, setTransactionDetails] = useState(null);
 	const [isLoading, setIsLoading] = useState(true);
 	const [isError, setIsError] = useState(false);
@@ -42,7 +44,7 @@ const FileInfo = (props: FileInfoProps) => {
 		(async () => {
 			try {
 				const transactionDetailResponse =
-					await getTransactionDetails(props.fileData.directory, props.cancellationToken);
+					await getTransactionDetails(props.fileData.directory, cancellationTokenSource.token);
 
 				setTransactionDetails(transactionDetailResponse);
 			}
@@ -54,7 +56,12 @@ const FileInfo = (props: FileInfoProps) => {
 			}
 		})();
 
-	}, [setIsLoading, setIsError, setTransactionDetails, props.fileData.directory, props.cancellationToken]);
+		return () => {
+			cancellationTokenSource.cancel();
+		}
+
+		// eslint-disable-next-line
+	}, [setIsLoading, setIsError, setTransactionDetails, props.fileData.directory]);
 
 	let background = null;
 	switch (props.fileData.risk as Risk) {

--- a/server/frontend/src/views/RequestHistory/FileInfo/FileInfo.tsx
+++ b/server/frontend/src/views/RequestHistory/FileInfo/FileInfo.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { CancelToken } from "axios";
 import {
 	Table,
 	TableHead,
@@ -25,7 +26,8 @@ interface FileData {
 }
 
 export interface FileInfoProps {
-	fileData: FileData
+	fileData: FileData,
+	cancellationToken: CancelToken
 }
 
 const FileInfo = (props: FileInfoProps) => {
@@ -37,12 +39,12 @@ const FileInfo = (props: FileInfoProps) => {
 		setIsLoading(true);
 		setIsError(false);
 
-		const getDetails = async () => {
+		(async () => {
 			try {
 				const transactionDetailResponse =
-					await getTransactionDetails(props.fileData.directory);
+					await getTransactionDetails(props.fileData.directory, props.cancellationToken);
 
-				setTransactionDetails(JSON.parse(transactionDetailResponse));
+				setTransactionDetails(transactionDetailResponse);
 			}
 			catch (error) {
 				setIsError(true);
@@ -50,9 +52,7 @@ const FileInfo = (props: FileInfoProps) => {
 			finally {
 				setIsLoading(false);
 			}
-		}
-
-		getDetails();
+		})();
 
 	}, [setIsLoading, setIsError, setTransactionDetails, props.fileData.directory]);
 

--- a/server/frontend/src/views/RequestHistory/FileInfo/FileInfo.tsx
+++ b/server/frontend/src/views/RequestHistory/FileInfo/FileInfo.tsx
@@ -54,7 +54,7 @@ const FileInfo = (props: FileInfoProps) => {
 			}
 		})();
 
-	}, [setIsLoading, setIsError, setTransactionDetails, props.fileData.directory]);
+	}, [setIsLoading, setIsError, setTransactionDetails, props.fileData.directory, props.cancellationToken]);
 
 	let background = null;
 	switch (props.fileData.risk as Risk) {

--- a/server/frontend/src/views/RequestHistory/RequestHistory.tsx
+++ b/server/frontend/src/views/RequestHistory/RequestHistory.tsx
@@ -233,8 +233,7 @@ const RequestHistory = () => {
 						<>
 							<Modal onCloseHandler={closeInfoModal} externalStyles={classes.modal}>
 								<FileInfo
-									fileData={selectedFile}
-									cancellationToken={cancellationTokenSource.token} />
+									fileData={selectedFile} />
 							</Modal>
 							<Backdrop onClickOutside={closeInfoModal} />
 						</>

--- a/server/frontend/src/views/RequestHistory/api/getTranasctions.ts
+++ b/server/frontend/src/views/RequestHistory/api/getTranasctions.ts
@@ -1,21 +1,25 @@
+import axios, { CancelToken } from "axios";
 import Routes from "../../../Routes";
 import { Filter } from "../../../../../src/common/models/TransactionEventService/GetTransactions/GetTransactionsRequest";
+import { GetTransactionsResponse } from "../../../../../src/common/models/TransactionEventService/GetTransactions";
 
 const requestHistoryRoutes = Routes.requestHistoryRoutes;
 
-export const getTransactions = async (body: Filter): Promise<string> => {
-    const response = await fetch(requestHistoryRoutes.getTransactionsRoute, {
+export const getTransactions = async (body: Filter, cancellationToken: CancelToken): Promise<GetTransactionsResponse> => {
+    const response = await axios(requestHistoryRoutes.getTransactionsRoute, {
         method: "POST",
-        body: JSON.stringify({ Filter: body }),
+        data: JSON.stringify({ Filter: body }),
         headers: {
             'Accept': '*/*',
             'Content-Type': 'application/json'
-        }
+        },
+        cancelToken: cancellationToken
     });
 
-    if (!response.ok) {
+    if (response.statusText !== "OK") {
         throw response.statusText;
     }
 
-    return response.text();
+    return response.data;
+
 };

--- a/server/frontend/src/views/RequestHistory/api/getTransactionDetails.ts
+++ b/server/frontend/src/views/RequestHistory/api/getTransactionDetails.ts
@@ -1,21 +1,23 @@
+import axios, { CancelToken } from "axios";
 import Routes from "../../../Routes";
 
 const requestHistoryRoutes = Routes.requestHistoryRoutes
 
-export const getTransactionDetails = async (transactionFilePath: string): Promise<string> => {
+export const getTransactionDetails = async (transactionFilePath: string, cancellationToken: CancelToken): Promise<string> => {
     const url = `${requestHistoryRoutes.getTransactionDetailsRoute}/${encodeURIComponent(transactionFilePath)}`;
 
-    const response = await fetch(url, {
+    const response = await axios(url, {
         method: "GET",
         headers: {
             'Accept': '*/*',
             'Content-Type': 'application/json'
-        }
+        },
+        cancelToken: cancellationToken
     });
 
-    if (!response.ok) {
+    if (response.statusText !== "OK") {
         throw response.statusText;
     }
 
-    return response.text();
+    return response.data;
 };

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -4,9 +4,6 @@
 module.exports = {
     // Automatically clear mock calls and instances between every test
     clearMocks: true,
-
-    // Indicates which provider should be used to instrument code for coverage
-    coverageProvider: "v8",
   
     // Allows you to use a custom runner instead of Jest's default test runner
     runner: "jest-runner",

--- a/server/package.json
+++ b/server/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/filetrust/icap-management-ui#readme",
   "devDependencies": {
+    "@types/axios": "^0.14.0",
     "@types/cors": "^2.8.8",
     "@types/express": "^4.17.8",
     "@types/node": "^14.10.2",
@@ -43,6 +44,7 @@
   "dependencies": {
     "@types/node-fetch": "^2.5.7",
     "@types/sinon": "^9.0.8",
+    "axios": "^0.21.0",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "cross-env": "^7.0.2",

--- a/server/src/business/services/PolicyManagementService/PolicyManagementService.test.ts
+++ b/server/src/business/services/PolicyManagementService/PolicyManagementService.test.ts
@@ -264,11 +264,6 @@ describe("PolicyManagementService", () => {
     describe("getPolicyHistory", () => {
         let getPolicyHistoryStub: SinonStub;
 
-        const responseString = {
-            policiesCount: 1,
-            policies: [policyExample]
-        };
-
         const policyHistory = new PolicyHistory(
             1,
             [new Policy(

--- a/server/src/business/services/PolicyManagementService/PolicyManagementService.test.ts
+++ b/server/src/business/services/PolicyManagementService/PolicyManagementService.test.ts
@@ -74,6 +74,9 @@ describe("PolicyManagementService", () => {
         const responseString = policyExample;
 
         beforeEach(() => {
+            const cancellationTokenSource = axios.CancelToken.source();
+            cancellationToken = cancellationTokenSource.token;
+
             getPolicyByIdStub = stub(PolicyManagementApi, "getPolicyById")
                 .resolves(JSON.stringify(responseString));
         });
@@ -88,7 +91,7 @@ describe("PolicyManagementService", () => {
             const request = new GetPolicyByIdRequest("www.glasswall.com", Guid.create());
 
             // Act
-            const result = await policyManagementService.getPolicy(request);
+            const result = await policyManagementService.getPolicy(request, cancellationToken);
 
             // Assert
             expect(result).toEqual(expectedGetPolicyResponse);
@@ -144,6 +147,9 @@ describe("PolicyManagementService", () => {
         const expectedHeaders = { "Content-Type": "application/json" };
 
         beforeEach(() => {
+            const cancellationTokenSource = axios.CancelToken.source();
+            cancellationToken = cancellationTokenSource.token;
+
             saveDraftPolicyStub = stub(PolicyManagementApi, "saveDraftPolicy")
                 .resolves();
         });
@@ -159,11 +165,11 @@ describe("PolicyManagementService", () => {
 
             // Act
             await policyManagementService.saveDraftPolicy(
-                saveDraftPolicyUrl, draftPolicy);
+                saveDraftPolicyUrl, draftPolicy, cancellationToken);
 
             // Assert
             expect(spy).toHaveBeenCalled();
-            expect(spy).toBeCalledWith(saveDraftPolicyUrl, draftPolicy, expectedHeaders);
+            expect(spy).toBeCalledWith(saveDraftPolicyUrl, draftPolicy, cancellationToken, expectedHeaders);
         });
     });
 
@@ -247,11 +253,11 @@ describe("PolicyManagementService", () => {
 
             // Act
             await policyManagementService.deleteDraftPolicy(
-                deleteDraftPolicyUrl, policyId);
+                deleteDraftPolicyUrl, policyId, cancellationToken);
 
             // Assert
             expect(spy).toHaveBeenCalled();
-            expect(spy).toBeCalledWith(deleteDraftPolicyUrl, policyId, expectedHeaders);
+            expect(spy).toBeCalledWith(deleteDraftPolicyUrl, policyId, cancellationToken, expectedHeaders);
         });
     });
 

--- a/server/src/business/services/PolicyManagementService/PolicyManagementService.ts
+++ b/server/src/business/services/PolicyManagementService/PolicyManagementService.ts
@@ -6,6 +6,7 @@ import { PolicyHistory } from "../../../common/models/PolicyManagementService/Po
 
 import IPolicyManagementService from "../../../common/services/IPolicyManagementService";
 import PolicyManagementApi from "../../../common/http/PolicyManagementApi/PolicyManagementApi";
+import { CancelToken } from "axios";
 
 class PolicyManagementService implements IPolicyManagementService {
     logger: Logger;
@@ -43,53 +44,51 @@ class PolicyManagementService implements IPolicyManagementService {
             }
         }
         catch (error) {
-            this.logger.error(`Could not get Policy - PolicyId: ${request.policyId}`);
+            this.logger.error(`Could not get Policy: ${error}`);
             throw error;
         }
 
         return policy;
     }
 
-    getCurrentPolicy = async (getCurrentPolicyUrl: string) => {
+    getCurrentPolicy = async (getCurrentPolicyUrl: string, cancellationToken: CancelToken) => {
         let policy: Policy;
 
         try {
             this.logger.info("Retrieving Current Policy from the PolicyManagementService");
 
             const response = await PolicyManagementApi.getPolicy(
-                getCurrentPolicyUrl, { "Content-Type": "application/json" });
-            const responseJSON = JSON.parse(response);
-            policy = this.createPolicyModel(responseJSON);
+                getCurrentPolicyUrl, cancellationToken, { "Content-Type": "application/json" });
+            policy = this.createPolicyModel(response);
 
             if (policy) {
                 this.logger.info(`Retrieved Current Policy - PolicyId: ${policy.id}`);
             }
         }
         catch (error) {
-            this.logger.error("Could not get Current Policy");
+            this.logger.error(`Could not get Current Policy: ${error}`);
             throw error;
         }
 
         return policy;
     }
 
-    getDraftPolicy = async (getDraftPolicyUrl: string) => {
+    getDraftPolicy = async (getDraftPolicyUrl: string, cancellationToken: CancelToken) => {
         let policy: Policy;
 
         try {
             this.logger.info("Retrieving Draft Policy from the PolicyManagementService");
 
             const response = await PolicyManagementApi.getPolicy(
-                getDraftPolicyUrl, { "Content-Type": "application/json" });
-            const responseJSON = JSON.parse(response);
-            policy = this.createPolicyModel(responseJSON);
+                getDraftPolicyUrl, cancellationToken, { "Content-Type": "application/json" });
+            policy = this.createPolicyModel(response);
 
             if (policy) {
                 this.logger.info(`Retrieved Draft Policy - PolicyId: ${policy.id}`);
             }
         }
         catch (error) {
-            this.logger.error("Could not get Draft Policy");
+            this.logger.error(`Could not get Draft Policy: ${error}`);
             throw error;
         }
 
@@ -149,20 +148,19 @@ class PolicyManagementService implements IPolicyManagementService {
         }
     }
 
-    getPolicyHistory = async (getPolicyHistoryUrl: string) => {
+    getPolicyHistory = async (getPolicyHistoryUrl: string, cancellationToken: CancelToken) => {
         let policyHistory: PolicyHistory;
 
         try {
             this.logger.info(`Retrieving Policy History from the PolicyManagementService`);
 
-            const response = await PolicyManagementApi.getPolicyHistory(getPolicyHistoryUrl);
-            const responseJSON = JSON.parse(response);
-            policyHistory = new PolicyHistory(responseJSON.policiesCount, responseJSON.policies);
+            const response = await PolicyManagementApi.getPolicyHistory(getPolicyHistoryUrl, cancellationToken);
+            policyHistory = new PolicyHistory(response.policiesCount, response.policies);
 
             this.logger.info(`Retrieved Policy History from the PolicyManagementService`);
         }
         catch (error) {
-            this.logger.error(`Couldn't Retrieve Policy History`);
+            this.logger.error(`Couldn't Retrieve Policy History: ${error}`);
             throw error;
         }
 

--- a/server/src/business/services/PolicyManagementService/PolicyManagementService.ts
+++ b/server/src/business/services/PolicyManagementService/PolicyManagementService.ts
@@ -28,14 +28,14 @@ class PolicyManagementService implements IPolicyManagementService {
         );
     }
 
-    getPolicy = async (request: GetPolicyByIdRequest) => {
+    getPolicy = async (request: GetPolicyByIdRequest, cancellationToken: CancelToken) => {
         let policy: Policy;
 
         try {
             this.logger.info(`Retrieving Policy from the PolicyManagementServie - PolicyId: ${request.policyId}`);
 
             const response = await PolicyManagementApi.getPolicyById(
-                request.url, request.policyId, { "Content-Type": "application/json" });
+                request.url, request.policyId, cancellationToken, { "Content-Type": "application/json" });
             const responseJSON = JSON.parse(response);
             policy = this.createPolicyModel(responseJSON);
 
@@ -95,20 +95,20 @@ class PolicyManagementService implements IPolicyManagementService {
         return policy;
     }
 
-    saveDraftPolicy = async (updatePolicyUrl: string, draftPolicy: Policy) => {
+    saveDraftPolicy = async (updatePolicyUrl: string, draftPolicy: Policy, cancellationToken: CancelToken) => {
         try {
             this.logger.info(
                 `Saving Draft Policy to the PolicyManagementService - PolicyId: ${draftPolicy.id}`);
 
             draftPolicy.updatedBy = "frontend.user@users.com";
             await PolicyManagementApi.saveDraftPolicy(
-                updatePolicyUrl, draftPolicy, { "Content-Type": "application/json" });
+                updatePolicyUrl, draftPolicy, cancellationToken, { "Content-Type": "application/json" });
 
             this.logger.info(
                 `Saved Draft Policy to the PolicyManagementService - PolicyId: ${draftPolicy.id}`)
         }
         catch (error) {
-            this.logger.error("Couldn't save Draft Policy");
+            this.logger.error(`Couldn't save Draft Policy: ${error}`);
             throw error;
         }
     }
@@ -134,16 +134,17 @@ class PolicyManagementService implements IPolicyManagementService {
         }
     }
 
-    deleteDraftPolicy = async (deleteDraftPolicyUrl: string, policyId: Guid) => {
+    deleteDraftPolicy = async (deleteDraftPolicyUrl: string, policyId: Guid, cancellationToken: CancelToken) => {
         try {
             this.logger.info(`Deleting Policy - PolicyId: ${policyId}`);
 
-            await PolicyManagementApi.deleteDraftPolicy(deleteDraftPolicyUrl, policyId, { "Content-Type": "application/json" });
+            await PolicyManagementApi.deleteDraftPolicy(
+                deleteDraftPolicyUrl, policyId, cancellationToken, { "Content-Type": "application/json" });
 
             this.logger.info(`Deleted Policy - PolicyId: ${policyId}`);
         }
         catch (error) {
-            this.logger.error(`Couldn't Delete Policy - PolicyId: ${policyId}`);
+            this.logger.error(`Couldn't Delete Policy: ${error}`);
             throw error;
         }
     }

--- a/server/src/business/services/TransactionEventService/TransactionEventService.test.ts
+++ b/server/src/business/services/TransactionEventService/TransactionEventService.test.ts
@@ -6,6 +6,7 @@ import { GetTransactionsRequest, GetTransactionsResponse } from "../../../common
 import { GetTransactionDetailsRequest, GetTransactionDetailsResponse } from "../../../common/models/TransactionEventService/GetTransactionDetails";
 import TransactionEventService from "./TransactionEventService";
 import TransactionEventApi from "../../../common/http/TransactionEventApi/TransactionEventApi";
+import axios, { CancelToken } from "axios";
 
 let getTransactionsStub: SinonStub;
 let getTransactionDetailsStub: SinonStub;
@@ -33,6 +34,8 @@ describe("TransactionEventService", () => {
             ]
         });
 
+        let cancellationToken: CancelToken;
+
         const responseString = {
             count: 1,
             files: [
@@ -51,8 +54,11 @@ describe("TransactionEventService", () => {
             responseString.count, responseString.files);
 
         beforeEach(() => {
+            const cancellationTokenSource = axios.CancelToken.source();
+            cancellationToken = cancellationTokenSource.token;
+
             getTransactionsStub = stub(TransactionEventApi, "getTransactions")
-                .resolves(JSON.stringify(responseString));
+                .resolves(responseString);
         });
 
         afterEach(() => {
@@ -71,7 +77,7 @@ describe("TransactionEventService", () => {
                 });
 
             // Act
-            const result = await transactionEventService.getTransactions(request);
+            const result = await transactionEventService.getTransactions(request, cancellationToken);
 
             // Assert
             expect(result).toEqual(expectedResponse);
@@ -87,6 +93,8 @@ describe("TransactionEventService", () => {
             ]
         });
 
+        let cancellationToken: CancelToken;
+
         const responseString = {
             status: 0,
             analysisReport: "test"
@@ -96,8 +104,11 @@ describe("TransactionEventService", () => {
             responseString.status, responseString.analysisReport)
 
         beforeEach(() => {
+            const cancellationTokenSource = axios.CancelToken.source();
+            cancellationToken = cancellationTokenSource.token;
+
             getTransactionDetailsStub = stub(TransactionEventApi, "getTransactionDetails")
-                .resolves(JSON.stringify(responseString));
+                .resolves(responseString);
         });
 
         afterEach(() => {
@@ -113,7 +124,7 @@ describe("TransactionEventService", () => {
             );
 
             // Act
-            const result = await transactionEventService.getTransactionDetails(request);
+            const result = await transactionEventService.getTransactionDetails(request, cancellationToken);
 
             // Assert
             expect(result).toEqual(expectedResponse);

--- a/server/src/business/services/TransactionEventService/TransactionEventService.ts
+++ b/server/src/business/services/TransactionEventService/TransactionEventService.ts
@@ -3,6 +3,7 @@ import ITransactionEventService from "../../../common/services/ITransactionEvent
 import { GetTransactionsRequest, GetTransactionsResponse } from "../../../common/models/TransactionEventService/GetTransactions";
 import { GetTransactionDetailsRequest, GetTransactionDetailsResponse } from "../../../common/models/TransactionEventService/GetTransactionDetails";
 import TransactionEventApi from "../../../common/http/TransactionEventApi/TransactionEventApi";
+import { CancelToken } from "axios";
 
 class TransactionEventService implements ITransactionEventService {
     logger: Logger;
@@ -11,44 +12,44 @@ class TransactionEventService implements ITransactionEventService {
         this.logger = logger;
     }
 
-    getTransactions = async (request: GetTransactionsRequest) => {
+    getTransactions = async (request: GetTransactionsRequest, cancellationToken: CancelToken) => {
         let transactions: GetTransactionsResponse;
 
         try {
             this.logger.info("Retrieving Transactions from the TransactionEventService");
 
-            const transactionsResponse = await TransactionEventApi.getTransactions(request.url, request.body, { "Content-Type": "application/json" });
-            const responseJSON = JSON.parse(transactionsResponse);
-            transactions = new GetTransactionsResponse(responseJSON.count, responseJSON.files);
+            const transactionsResponse = await TransactionEventApi.getTransactions(request.url, request.body, cancellationToken, { "Content-Type": "application/json" });
+            transactions = new GetTransactionsResponse(transactionsResponse.count, transactionsResponse.files);
 
             if (transactions) {
-                this.logger.info(`Retrieved ${transactions.count} Transactions: ${transactionsResponse}`);
+                this.logger.info(`Retrieved ${transactions.count} Transactions: ${JSON.stringify(transactionsResponse)}`);
             }
         }
         catch (error) {
-            this.logger.error(`Could not get Transactions: ${error} ${error.stack !== undefined ? error.stack : ""}`);
+            this.logger.error(`Could not get Transactions: ${error}`);
             throw error;
         }
 
         return transactions;
     };
 
-    getTransactionDetails = async (request: GetTransactionDetailsRequest) => {
+    getTransactionDetails = async (request: GetTransactionDetailsRequest, cancellationToken: CancelToken) => {
         let transactionDetails: GetTransactionDetailsResponse;
 
         try {
             this.logger.info(`Retrieving Transaction Details from the TransactionEventService - Directory: ${request.transactionFileDirectory}`);
 
-            const response = await TransactionEventApi.getTransactionDetails(request.url, request.transactionFileDirectory, { "Content-Type": "application/json" });
-            const responseJSON = JSON.parse(response);
-            transactionDetails = new GetTransactionDetailsResponse(responseJSON.status, responseJSON.analysisReport);
+            const response = await TransactionEventApi.getTransactionDetails(
+                request.url, request.transactionFileDirectory, cancellationToken, { "Content-Type": "application/json" });
+
+            transactionDetails = new GetTransactionDetailsResponse(response.status, response.analysisReport);
 
             if (transactionDetails) {
                 this.logger.info(`Retrieved Transaction Details from file: ${request.transactionFileDirectory}`);
             }
         }
         catch (error) {
-            this.logger.error(`Could not get Transaction Details from file: ${request.transactionFileDirectory}`);
+            this.logger.error(`Could not get Transaction Details: ${error}`);
             throw error;
         }
 

--- a/server/src/common/http/PolicyManagementApi/PolicyManagementApi.test.ts
+++ b/server/src/common/http/PolicyManagementApi/PolicyManagementApi.test.ts
@@ -13,6 +13,24 @@ let axiosStubResult: any;
 const url = "www.glasswall.com";
 let cancellationToken: CancelToken;
 
+const setUpCancellationToken = () => {
+    const cancellationTokenSource = axios.CancelToken.source();
+    cancellationToken = cancellationTokenSource.token;
+};
+
+const setAxiosStubResultWithError = () => {
+    axiosStubResult = {
+        status: 500,
+        statusText: "Error"
+    };
+};
+
+const expectAxios = (stubbedAxios: SinonStub, expectedUrl: string) => {
+    expect(stubbedAxios.getCalls()).toHaveLength(1);
+    expect(stubbedAxios.getCall(0).args).toHaveLength(2);
+    expect(stubbedAxios.getCall(0).args[0]).toEqual(expectedUrl);
+};
+
 const expectAxiosPut = (stubbedAxios: SinonStub, expectedUrl: string, data?: any) => {
     expect(stubbedAxios.getCalls()).toHaveLength(1);
     expect(stubbedAxios.getCall(0).args[0]).toEqual(expectedUrl);
@@ -27,12 +45,6 @@ const expectAxiosPut = (stubbedAxios: SinonStub, expectedUrl: string, data?: any
     }
 };
 
-const expectAxios = (stubbedAxios: SinonStub, expectedUrl: string) => {
-    expect(stubbedAxios.getCalls()).toHaveLength(1);
-    expect(stubbedAxios.getCall(0).args).toHaveLength(2);
-    expect(stubbedAxios.getCall(0).args[0]).toEqual(expectedUrl);
-};
-
 describe("PolicyManagementApi", () => {
     describe("getPolicyById", () => {
         describe("response_status_not_ok", () => {
@@ -42,13 +54,8 @@ describe("PolicyManagementApi", () => {
             const expectedError = new Error("Error");
 
             beforeEach(async () => {
-                const cancellationTokenSource = axios.CancelToken.source();
-                cancellationToken = cancellationTokenSource.token;
-
-                axiosStubResult = {
-                    status: 500,
-                    statusText: "Error"
-                };
+                setUpCancellationToken();
+                setAxiosStubResultWithError();
 
                 axiosStub = stub(axios, "get").returns(axiosStubResult);
 
@@ -117,13 +124,8 @@ describe("PolicyManagementApi", () => {
             const expectedError = new Error("Error");
 
             beforeEach(async () => {
-                const cancellationTokenSource = axios.CancelToken.source();
-                cancellationToken = cancellationTokenSource.token;
-
-                axiosStubResult = {
-                    status: 500,
-                    statusText: "Error"
-                };
+                setUpCancellationToken();
+                setAxiosStubResultWithError();
 
                 axiosStub = stub(axios, "get").returns(axiosStubResult);
 
@@ -149,7 +151,7 @@ describe("PolicyManagementApi", () => {
 
         describe("should_respond_with_response_json_if_OK", () => {
             // Arrange
-            const expectedResponse = { test: "test" };
+            const expectedResponse = { testResult: "test" };
             let result: Policy;
 
             beforeEach(async () => {
@@ -158,7 +160,7 @@ describe("PolicyManagementApi", () => {
 
                 axiosStubResult = {
                     statusText: "OK",
-                    data: { test: "test" }
+                    data: { testResult: "test" }
                 };
 
                 axiosStub = stub(axios, "get").returns(axiosStubResult);
@@ -201,13 +203,8 @@ describe("PolicyManagementApi", () => {
             );
 
             beforeEach(async () => {
-                const cancellationTokenSource = axios.CancelToken.source();
-                cancellationToken = cancellationTokenSource.token;
-
-                axiosStubResult = {
-                    status: 500,
-                    statusText: "Error"
-                };
+                setUpCancellationToken();
+                setAxiosStubResultWithError();
 
                 axiosStub = stub(axios, "put").returns(axiosStubResult);
 
@@ -245,10 +242,7 @@ describe("PolicyManagementApi", () => {
             const expectedError = new Error("Error");
 
             beforeEach(async () => {
-                axiosStubResult = {
-                    status: 500,
-                    statusText: "Error"
-                };
+                setAxiosStubResultWithError();
 
                 axiosStub = stub(axios, "put").returns(axiosStubResult);
 
@@ -284,10 +278,7 @@ describe("PolicyManagementApi", () => {
             const expectedError = new Error("Error");
 
             beforeEach(async () => {
-                axiosStubResult = {
-                    status: 500,
-                    statusText: "Error"
-                };
+                setAxiosStubResultWithError();
 
                 axiosStub = stub(axios, "put").returns(axiosStubResult);
 
@@ -323,10 +314,7 @@ describe("PolicyManagementApi", () => {
             const expectedError = new Error("Error");
 
             beforeEach(async () => {
-                axiosStubResult = {
-                    status: 500,
-                    statusText: "Error"
-                };
+                setAxiosStubResultWithError();
 
                 axiosStub = stub(axios, "put").returns(axiosStubResult);
 
@@ -364,13 +352,8 @@ describe("PolicyManagementApi", () => {
             const expectedError = new Error("Error");
 
             beforeEach(async () => {
-                const cancellationTokenSource = axios.CancelToken.source();
-                cancellationToken = cancellationTokenSource.token;
-
-                axiosStubResult = {
-                    status: 500,
-                    statusText: "Error"
-                };
+                setUpCancellationToken();
+                setAxiosStubResultWithError();
 
                 axiosStub = stub(axios, "delete").returns(axiosStubResult);
 
@@ -406,13 +389,8 @@ describe("PolicyManagementApi", () => {
             const expectedError = new Error("Error");
 
             beforeEach(async () => {
-                const cancellationTokenSource = axios.CancelToken.source();
-                cancellationToken = cancellationTokenSource.token;
-
-                axiosStubResult = {
-                    status: 500,
-                    statusText: "Error"
-                };
+                setUpCancellationToken();
+                setAxiosStubResultWithError();
 
                 axiosStub = stub(axios, "get").returns(axiosStubResult);
 

--- a/server/src/common/http/PolicyManagementApi/PolicyManagementApi.test.ts
+++ b/server/src/common/http/PolicyManagementApi/PolicyManagementApi.test.ts
@@ -9,6 +9,22 @@ import axios, { CancelToken } from "axios";
 let fetchStub: SinonStub;
 let fetchStubResult: any
 
+let axiosStub: SinonStub;
+let axiosStubResult: any;
+
+const expectAxiosPost = (stubbedAxios: SinonStub, expectedUrl: string, data: any) => {
+    expect(stubbedAxios.getCalls()).toHaveLength(1);
+    expect(stubbedAxios.getCall(0).args).toHaveLength(3);
+    expect(stubbedAxios.getCall(0).args[0]).toEqual(expectedUrl);
+    expect(stubbedAxios.getCall(0).args[1]).toEqual(data);
+};
+
+const expectAxiosGet = (stubbedAxios: SinonStub, expectedUrl: string) => {
+    expect(stubbedAxios.getCalls()).toHaveLength(1);
+    expect(stubbedAxios.getCall(0).args).toHaveLength(2);
+    expect(stubbedAxios.getCall(0).args[0]).toEqual(expectedUrl);
+};
+
 const expectFetch = (stubbedFetch: SinonStub,
     expectedUrl: string,
     method: "GET" | "POST" | "PUT" | "DELETE") => {
@@ -103,12 +119,12 @@ describe("PolicyManagementApi", () => {
                 const cancellationTokenSource = axios.CancelToken.source();
                 cancellationToken = cancellationTokenSource.token;
 
-                fetchStubResult = {
-                    ok: false,
+                axiosStubResult = {
+                    status: 500,
                     statusText: "Error"
                 };
 
-                fetchStub = stub(fetch, "default").returns(fetchStubResult);
+                axiosStub = stub(axios, "get").returns(axiosStubResult);
 
                 // Act
                 try {
@@ -120,7 +136,7 @@ describe("PolicyManagementApi", () => {
             });
 
             afterEach(() => {
-                fetchStub.restore();
+                axiosStub.restore();
             });
 
             // Assert
@@ -129,9 +145,10 @@ describe("PolicyManagementApi", () => {
                 expect(error).toEqual(expectedError);
             });
 
-            it("called_fetch_using_GET", () => {
-                expectFetch(fetchStub, url, "GET");
-            })
+            it("called_axios_using_GET", () => {
+                expectAxiosGet(
+                    axiosStub, url);
+            });
         });
 
         describe("should_respond_with_response_json_if_OK", () => {
@@ -145,19 +162,19 @@ describe("PolicyManagementApi", () => {
                 const cancellationTokenSource = axios.CancelToken.source();
                 cancellationToken = cancellationTokenSource.token;
 
-                fetchStubResult = {
-                    ok: true,
-                    text: () => { return { test: "test" } }
+                axiosStubResult = {
+                    statusText: "OK",
+                    data: { test: "test" }
                 };
 
-                fetchStub = stub(fetch, "default").returns(fetchStubResult);
+                axiosStub = stub(axios, "get").returns(axiosStubResult);
 
                 // Act
                 result = await PolicyManagementApi.getPolicy(url, cancellationToken);
             });
 
             afterEach(() => {
-                fetchStub.restore();
+                axiosStub.restore();
             });
 
             // Assert
@@ -166,8 +183,8 @@ describe("PolicyManagementApi", () => {
                 expect(result).toEqual(expectedResponse);
             });
 
-            it("called_fetch_using_GET", () => {
-                expectFetch(fetchStub, url, "GET");
+            it("called_axios_using_GET", () => {
+                expectAxiosGet(axiosStub, url);
             });
         });
     });

--- a/server/src/common/http/PolicyManagementApi/PolicyManagementApi.test.ts
+++ b/server/src/common/http/PolicyManagementApi/PolicyManagementApi.test.ts
@@ -10,6 +10,9 @@ import policyExample from "./policyExample.json";
 let axiosStub: SinonStub;
 let axiosStubResult: any;
 
+const url = "www.glasswall.com";
+let cancellationToken: CancelToken;
+
 const expectAxiosPut = (stubbedAxios: SinonStub, expectedUrl: string, data?: any) => {
     expect(stubbedAxios.getCalls()).toHaveLength(1);
     expect(stubbedAxios.getCall(0).args[0]).toEqual(expectedUrl);
@@ -34,9 +37,7 @@ describe("PolicyManagementApi", () => {
     describe("getPolicyById", () => {
         describe("response_status_not_ok", () => {
             // Arrange
-            const url = "www.glasswall.com";
             const policyId = Guid.create();
-            let cancellationToken: CancelToken;
             let error: any;
             const expectedError = new Error("Error");
 
@@ -73,11 +74,9 @@ describe("PolicyManagementApi", () => {
 
         describe("should_respond_with_response_json_if_OK", () => {
             // Arrange
-            const url = "www.glasswall.com";
             const policyId = Guid.create();
             const expectedRequestUrl = `${url}?id=${policyId.toString()}`;
             const expectedResponse = { test: "test" };
-            let cancellationToken: CancelToken;
             let result: string;
 
             beforeEach(async () => {
@@ -114,8 +113,6 @@ describe("PolicyManagementApi", () => {
     describe("getPolicy", () => {
         describe("response_status_not_OK", () => {
             // Arrange
-            const url = "www.glasswall.com";
-            let cancellationToken: CancelToken;
             let error: any;
             const expectedError = new Error("Error");
 
@@ -152,9 +149,7 @@ describe("PolicyManagementApi", () => {
 
         describe("should_respond_with_response_json_if_OK", () => {
             // Arrange
-            const url = "www.glasswall.com";
             const expectedResponse = { test: "test" };
-            let cancellationToken: CancelToken;
             let result: Policy;
 
             beforeEach(async () => {
@@ -191,8 +186,6 @@ describe("PolicyManagementApi", () => {
     describe("saveDraftPolicy", () => {
         describe("response_status_not_OK", () => {
             // Arrange
-            const url = "www.glasswall.com";
-            let cancellationToken: CancelToken;
             let error: any;
             const expectedError = new Error("Error");
 
@@ -246,7 +239,6 @@ describe("PolicyManagementApi", () => {
     describe("publishPolicy", () => {
         describe("response_status_not_OK", () => {
             // Arrange
-            const url = "www.glasswall.com";
             const policyId = Guid.create();
             const expectedRequestUrl = `${url}?id=${policyId.toString()}`;
             let error: any;
@@ -288,7 +280,6 @@ describe("PolicyManagementApi", () => {
     describe("distributeAdaptationPolicy", () => {
         describe("response_status_not_OK", () => {
             // Arrange
-            const url = "www.glasswall.com";
             let error: any;
             const expectedError = new Error("Error");
 
@@ -328,7 +319,6 @@ describe("PolicyManagementApi", () => {
     describe("distributeNcfsPolicy", () => {
         describe("response_status_not_OK", () => {
             // Arrange
-            const url = "www.glasswall.com";
             let error: any;
             const expectedError = new Error("Error");
 
@@ -368,10 +358,8 @@ describe("PolicyManagementApi", () => {
     describe("deleteDraftPolicy", () => {
         describe("response_status_not_OK", () => {
             // Arrange
-            const url = "www.glasswall.com";
             const policyId = Guid.create();
             const expectedRequestUrl = `${url}?id=${policyId.toString()}`;
-            let cancellationToken: CancelToken;
             let error: any;
             const expectedError = new Error("Error");
 
@@ -414,8 +402,6 @@ describe("PolicyManagementApi", () => {
     describe("_getPolicyHistory", () => {
         describe("response_status_not_OK", () => {
             // Arrange
-            const url = "www.glasswall.com";
-            let cancellationToken: CancelToken;
             let error: any;
             const expectedError = new Error("Error");
 
@@ -452,9 +438,7 @@ describe("PolicyManagementApi", () => {
 
         describe("should_respond_with_response_json_if_OK", () => {
             // Arrange
-            const url = "www.glasswall.com";
             const expectedResponse = ["test"];
-            let cancellationToken: CancelToken;
             let result: PolicyHistory;
 
             beforeEach(async () => {

--- a/server/src/common/http/PolicyManagementApi/PolicyManagementApi.test.ts
+++ b/server/src/common/http/PolicyManagementApi/PolicyManagementApi.test.ts
@@ -4,6 +4,7 @@ import fetch = require("node-fetch");
 import { Guid } from "guid-typescript";
 import { Policy } from "../../../common/models/PolicyManagementService/Policy/Policy";
 import policyExample from "./policyExample.json";
+import axios, { CancelToken } from "axios";
 
 let fetchStub: SinonStub;
 let fetchStubResult: any
@@ -94,10 +95,14 @@ describe("PolicyManagementApi", () => {
         describe("response_status_not_OK", () => {
             // Arrange
             const url = "www.glasswall.com";
+            let cancellationToken: CancelToken;
             let error: any;
             const expectedError = new Error("Error");
 
             beforeEach(async () => {
+                const cancellationTokenSource = axios.CancelToken.source();
+                cancellationToken = cancellationTokenSource.token;
+
                 fetchStubResult = {
                     ok: false,
                     statusText: "Error"
@@ -107,7 +112,7 @@ describe("PolicyManagementApi", () => {
 
                 // Act
                 try {
-                    await PolicyManagementApi.getPolicy(url);
+                    await PolicyManagementApi.getPolicy(url, cancellationToken);
                 }
                 catch (err) {
                     error = err;
@@ -133,9 +138,13 @@ describe("PolicyManagementApi", () => {
             // Arrange
             const url = "www.glasswall.com";
             const expectedResponse = { test: "test" };
-            let result: string;
+            let cancellationToken: CancelToken;
+            let result: Policy;
 
             beforeEach(async () => {
+                const cancellationTokenSource = axios.CancelToken.source();
+                cancellationToken = cancellationTokenSource.token;
+
                 fetchStubResult = {
                     ok: true,
                     text: () => { return { test: "test" } }
@@ -144,7 +153,7 @@ describe("PolicyManagementApi", () => {
                 fetchStub = stub(fetch, "default").returns(fetchStubResult);
 
                 // Act
-                result = await PolicyManagementApi.getPolicy(url);
+                result = await PolicyManagementApi.getPolicy(url, cancellationToken);
             });
 
             afterEach(() => {
@@ -382,10 +391,14 @@ describe("PolicyManagementApi", () => {
         describe("response_status_not_OK", () => {
             // Arrange
             const url = "www.glasswall.com";
+            let cancellationToken: CancelToken;
             let error: any;
             const expectedError = new Error("Error");
 
             beforeEach(async () => {
+                const cancellationTokenSource = axios.CancelToken.source();
+                cancellationToken = cancellationTokenSource.token;
+
                 fetchStubResult = {
                     ok: false,
                     statusText: "Error"
@@ -395,7 +408,7 @@ describe("PolicyManagementApi", () => {
 
                 // Act
                 try {
-                    await PolicyManagementApi.getPolicyHistory(url);
+                    await PolicyManagementApi.getPolicyHistory(url, cancellationToken);
                 }
                 catch (err) {
                     error = err;

--- a/server/src/common/http/PolicyManagementApi/PolicyManagementApi.ts
+++ b/server/src/common/http/PolicyManagementApi/PolicyManagementApi.ts
@@ -1,6 +1,8 @@
-import { Guid } from "guid-typescript";
+import axios, { CancelToken } from "axios";
 import fetch from "node-fetch";
+import { Guid } from "guid-typescript";
 import { Policy } from "../../../common/models/PolicyManagementService/Policy/Policy";
+import { PolicyHistory } from "../../../common/models/PolicyManagementService/PolicyHistory/PolicyHistory";
 
 export default class PolicyManagementApi {
     static getPolicyById = async (getPolicyByIdUrl: string, policyId: Guid, headers?: { [header: string]: string }): Promise<string> => {
@@ -18,17 +20,21 @@ export default class PolicyManagementApi {
         return response.text();
     }
 
-    static getPolicy = async (getPolicyUrl: string, headers?: { [header: string]: string }): Promise<string> => {
-        const response = await fetch(getPolicyUrl, {
-            method: "GET",
-            headers
+    static getPolicy = async (
+        getPolicyUrl: string,
+        cancellationToken: CancelToken,
+        headers?: { [header: string]: string }): Promise<Policy> => {
+
+        const response = await axios.get(getPolicyUrl, {
+            headers,
+            cancelToken: cancellationToken
         });
 
-        if (!response.ok) {
+        if (response.statusText !== "OK") {
             throw new Error(response.statusText);
         }
 
-        return response.text();
+        return response.data;
     }
 
     static saveDraftPolicy = async (saveDraftPolicyUrl: string, draftPolicy: Policy, headers?: { [header: string]: string }): Promise<void> => {
@@ -91,16 +97,20 @@ export default class PolicyManagementApi {
         }
     }
 
-    static getPolicyHistory = async (getPolicyHistoryUrl: string, headers?: { [header: string]: string }): Promise<string> => {
-        const response = await fetch(getPolicyHistoryUrl, {
-            method: "GET",
-            headers
+    static getPolicyHistory = async (
+        getPolicyHistoryUrl: string,
+        cancellationToken: CancelToken,
+        headers?: { [header: string]: string }
+    ): Promise<PolicyHistory> => {
+        const response = await axios.get(getPolicyHistoryUrl, {
+            headers,
+            cancelToken: cancellationToken
         });
 
-        if (!response.ok) {
+        if (response.statusText !== "OK") {
             throw new Error(response.statusText);
         }
 
-        return response.text();
+        return response.data;
     };
 }

--- a/server/src/common/http/PolicyManagementApi/PolicyManagementApi.ts
+++ b/server/src/common/http/PolicyManagementApi/PolicyManagementApi.ts
@@ -1,23 +1,27 @@
 import axios, { CancelToken } from "axios";
-import fetch from "node-fetch";
 import { Guid } from "guid-typescript";
 import { Policy } from "../../../common/models/PolicyManagementService/Policy/Policy";
 import { PolicyHistory } from "../../../common/models/PolicyManagementService/PolicyHistory/PolicyHistory";
 
 export default class PolicyManagementApi {
-    static getPolicyById = async (getPolicyByIdUrl: string, policyId: Guid, headers?: { [header: string]: string }): Promise<string> => {
+    static getPolicyById = async (
+        getPolicyByIdUrl: string,
+        policyId: Guid,
+        cancellationToken: CancelToken,
+        headers?: { [header: string]: string }): Promise<string> => {
+
         const url = `${getPolicyByIdUrl}?id=${policyId.toString()}`;
 
-        const response = await fetch(url, {
-            method: "GET",
-            headers
+        const response = await axios.get(url, {
+            headers,
+            cancelToken: cancellationToken
         });
 
-        if (!response.ok) {
+        if (response.statusText !== "OK") {
             throw new Error(response.statusText);
         }
 
-        return response.text();
+        return response.data;
     }
 
     static getPolicy = async (
@@ -37,64 +41,79 @@ export default class PolicyManagementApi {
         return response.data;
     }
 
-    static saveDraftPolicy = async (saveDraftPolicyUrl: string, draftPolicy: Policy, headers?: { [header: string]: string }): Promise<void> => {
-        const response = await fetch(saveDraftPolicyUrl, {
-            method: "PUT",
-            body: JSON.stringify(draftPolicy),
-            headers
+    static saveDraftPolicy = async (
+        saveDraftPolicyUrl: string,
+        draftPolicy: Policy,
+        cancellationToken: CancelToken,
+        headers?: { [header: string]: string }): Promise<void> => {
+
+        const response = await axios.put(saveDraftPolicyUrl, JSON.stringify(draftPolicy), {
+            headers,
+            cancelToken: cancellationToken
         });
 
-        if (!response.ok) {
+        if (response.statusText !== "OK") {
             throw new Error(response.statusText);
         }
+
+        return response.data;
     }
 
     static publishPolicy = async (publishPolicyUrl: string, policyId: Guid, headers?: { [header: string]: string }): Promise<void> => {
         const url = `${publishPolicyUrl}?id=${policyId.toString()}`;
 
-        const response = await fetch(url, {
-            method: "PUT",
+        const response = await axios.put(url, {
             headers
         });
 
-        if (!response.ok) {
+        if (response.statusText !== "OK") {
             throw new Error(response.statusText);
         }
+
+        return response.data;
     }
 
     static distributeAdaptationPolicy = async (distributeAdaptationPolicyUrl: string, headers?: { [header: string]: string }): Promise<void> => {
-        const response = await fetch(distributeAdaptationPolicyUrl, {
-            method: "PUT",
+        const response = await axios.put(distributeAdaptationPolicyUrl, {
             headers
         });
 
-        if (!response.ok) {
+        if (response.statusText !== "OK") {
             throw new Error(response.statusText);
         }
+
+        return response.data;
     }
 
     static distributeNcfsPolicy = async (distributeNcfsPolicyUrl: string, headers?: { [header: string]: string }): Promise<void> => {
-        const response = await fetch(distributeNcfsPolicyUrl, {
-            method: "PUT",
+        const response = await axios.put(distributeNcfsPolicyUrl, {
             headers
         });
 
-        if (!response.ok) {
+        if (response.statusText !== "OK") {
             throw new Error(response.statusText);
         }
+
+        return response.data;
     }
 
-    static deleteDraftPolicy = async (deleteDraftPolicyUrl: string, policyId: Guid, headers?: { [header: string]: string }): Promise<void> => {
+    static deleteDraftPolicy = async (
+        deleteDraftPolicyUrl: string,
+        policyId: Guid,
+        cancellationToken: CancelToken,
+        headers?: { [header: string]: string }): Promise<void> => {
         const url = `${deleteDraftPolicyUrl}?id=${policyId.toString()}`;
 
-        const response = await fetch(url, {
-            method: "DELETE",
-            headers
+        const response = await axios.delete(url, {
+            headers,
+            cancelToken: cancellationToken
         });
 
-        if (!response.ok) {
+        if (response.statusText !== "OK") {
             throw new Error(response.statusText);
         }
+
+        return response.data;
     }
 
     static getPolicyHistory = async (

--- a/server/src/common/http/TransactionEventApi/TransactionEventApi.test.ts
+++ b/server/src/common/http/TransactionEventApi/TransactionEventApi.test.ts
@@ -14,7 +14,7 @@ const expectAxiosPost = (stubbedAxios: SinonStub, expectedUrl: string, data: any
     expect(stubbedAxios.getCall(0).args[1]).toEqual(data);
 };
 
-const expectAxiosGet = (stubbedAxios: SinonStub, expectedUrl: string, data: any) => {
+const expectAxiosGet = (stubbedAxios: SinonStub, expectedUrl: string) => {
     expect(stubbedAxios.getCalls()).toHaveLength(1);
     expect(stubbedAxios.getCall(0).args).toHaveLength(2);
     expect(stubbedAxios.getCall(0).args[0]).toEqual(expectedUrl);
@@ -59,7 +59,7 @@ describe("TransactionEventApi", () => {
                 expect(error).toEqual(expectedError);
             });
 
-            it("called_fetch_using_POST", () => {
+            it("called_axios_using_POST", () => {
                 expectAxiosPost(axiosStub, url, JSON.stringify({}));
             });
         });
@@ -140,8 +140,9 @@ describe("TransactionEventApi", () => {
                 expect(error).toEqual(expectedError);
             });
 
-            it("called_fetch_using_GET", () => {
-                expectAxiosGet(axiosStub, `${url}?filePath=${transactionFilePath}`, ["test"]);
+            it("called_axios_using_GET", () => {
+                expectAxiosGet(
+                    axiosStub, `${url}?filePath=${transactionFilePath}`);
             });
         });
 
@@ -180,7 +181,7 @@ describe("TransactionEventApi", () => {
             });
 
             it("called_fetch_using_GET", () => {
-                expectAxiosGet(axiosStub, expectedRequestUrl, ["test"]);
+                expectAxiosGet(axiosStub, expectedRequestUrl);
             });
         });
     });

--- a/server/src/common/http/TransactionEventApi/TransactionEventApi.test.ts
+++ b/server/src/common/http/TransactionEventApi/TransactionEventApi.test.ts
@@ -1,6 +1,5 @@
 import { stub, SinonStub } from "sinon";
 import axios, { CancelToken } from "axios";
-import fetch = require("node-fetch");
 
 import TransactionEventApi, { File } from "./TransactionEventApi";
 
@@ -57,10 +56,6 @@ describe("TransactionEventApi", () => {
             it("responds_with_status_text", () => {
                 expect(error).not.toBe(undefined);
                 expect(error).toEqual(expectedError);
-            });
-
-            it("called_axios_using_POST", () => {
-                expectAxiosPost(axiosStub, url, JSON.stringify({}));
             });
         });
 
@@ -138,11 +133,6 @@ describe("TransactionEventApi", () => {
             it("responds_with_status_text", () => {
                 expect(error).not.toBe(undefined);
                 expect(error).toEqual(expectedError);
-            });
-
-            it("called_axios_using_GET", () => {
-                expectAxiosGet(
-                    axiosStub, `${url}?filePath=${transactionFilePath}`);
             });
         });
 

--- a/server/src/common/http/TransactionEventApi/TransactionEventApi.test.ts
+++ b/server/src/common/http/TransactionEventApi/TransactionEventApi.test.ts
@@ -20,6 +20,7 @@ describe("TransactionEventApi", () => {
             // Arrange
             const url = "www.glasswall.com";
             let error: any;
+            const expectedError = new Error("Error");
 
             beforeEach(async () => {
                 fetchStubResult = {
@@ -45,7 +46,7 @@ describe("TransactionEventApi", () => {
             // Assert
             it("responds_with_status_text", () => {
                 expect(error).not.toBe(undefined);
-                expect(error).toEqual("Error");
+                expect(error).toEqual(expectedError);
             });
 
             it("called_fetch_using_POST", () => {
@@ -92,6 +93,7 @@ describe("TransactionEventApi", () => {
             const url = "www.glasswall.com";
             const transactionFilePath = "/test";
             let error: any;
+            const expectedError = new Error("Error");
 
             beforeEach(async () => {
                 fetchStubResult = {
@@ -117,7 +119,7 @@ describe("TransactionEventApi", () => {
             // Assert
             it("responds_with_status_text", () => {
                 expect(error).not.toBe(undefined);
-                expect(error).toEqual("Error");
+                expect(error).toEqual(expectedError);
             });
 
             it("called_fetch_using_GET", () => {

--- a/server/src/common/http/TransactionEventApi/TransactionEventApi.ts
+++ b/server/src/common/http/TransactionEventApi/TransactionEventApi.ts
@@ -9,7 +9,7 @@ export default class TransactionEventApi {
         });
 
         if (!response.ok) {
-            throw response.statusText;
+            throw new Error(response.statusText);
         }
 
         return response.text();
@@ -24,7 +24,7 @@ export default class TransactionEventApi {
         });
 
         if (!response.ok) {
-            throw response.statusText;
+            throw new Error(response.statusText);
         }
 
         return response.text();

--- a/server/src/common/http/TransactionEventApi/TransactionEventApi.ts
+++ b/server/src/common/http/TransactionEventApi/TransactionEventApi.ts
@@ -1,32 +1,61 @@
 import fetch from "node-fetch";
+import axios, { CancelToken } from "axios";
+import { FileType } from "../../../common/models/enums/FileType";
+import { Risk } from "../../../common/models/enums/Risk";
+
+export interface File {
+    timestamp: Date,
+    fileId: string,
+    detectionFileType: FileType,
+    risk: Risk,
+    activePolicyId: string,
+    directory: string
+}
 
 export default class TransactionEventApi {
-    static getTransactions = async (getTransactionsUrl: string, body: any, headers?: { [header: string]: string }): Promise<string> => {
-        const response = await fetch(`${getTransactionsUrl}`, {
-            method: "POST",
-            body: JSON.stringify(body),
-            headers
-        });
+    static getTransactions = async (
+        getTransactionsUrl: string,
+        body: any,
+        cancellationToken: CancelToken,
+        headers?: { [header: string]: string }
+    ): Promise<{ count: number, files: File[] }> => {
+        const response = await axios.post(
+            getTransactionsUrl,
+            JSON.stringify(body),
+            {
+                data: JSON.stringify(body),
+                headers,
+                cancelToken: cancellationToken
+            }
+        );
 
-        if (!response.ok) {
+        if (response.statusText !== "OK") {
             throw new Error(response.statusText);
         }
 
-        return response.text();
+        return response.data;
     };
 
-    static getTransactionDetails = async (getTransactionDetailsUrl: string, transactionFilePath: string, headers?: { [header: string]: string }): Promise<string> => {
+    static getTransactionDetails = async (
+        getTransactionDetailsUrl: string,
+        transactionFilePath: string,
+        cancellationToken: CancelToken,
+        headers?: { [header: string]: string }
+    ): Promise<{ status: number, analysisReport: string }> => {
         const url = `${getTransactionDetailsUrl}?filePath=${transactionFilePath}`;
 
-        const response = await fetch(url, {
-            method: "GET",
-            headers
-        });
+        const response = await axios.get(
+            url,
+            {
+                headers,
+                cancelToken: cancellationToken
+            }
+        );
 
-        if (!response.ok) {
+        if (response.statusText !== "OK") {
             throw new Error(response.statusText);
         }
 
-        return response.text();
+        return response.data;
     }
 }

--- a/server/src/common/http/TransactionEventApi/TransactionEventApi.ts
+++ b/server/src/common/http/TransactionEventApi/TransactionEventApi.ts
@@ -1,4 +1,3 @@
-import fetch from "node-fetch";
 import axios, { CancelToken } from "axios";
 import { FileType } from "../../../common/models/enums/FileType";
 import { Risk } from "../../../common/models/enums/Risk";

--- a/server/src/common/services/IPolicyManagementService.ts
+++ b/server/src/common/services/IPolicyManagementService.ts
@@ -7,11 +7,11 @@ import { PolicyHistory } from "../models/PolicyManagementService/PolicyHistory/P
 
 export default interface IPolicyManagementService {
     logger: Logger,
-    getPolicy: (request: GetPolicyByIdRequest) => Promise<Policy>,
+    getPolicy: (request: GetPolicyByIdRequest, cancellationToken: CancelToken) => Promise<Policy>,
     getCurrentPolicy: (getCurrentPolicyUrl: string, cancellationToken: CancelToken) => Promise<Policy>,
     getDraftPolicy: (getDraftPolicyUrl: string, cancellationToken: CancelToken) => Promise<Policy>,
-    saveDraftPolicy: (saveDraftPolicyUrl: string, draftPolicy: Policy) => Promise<void>,
+    saveDraftPolicy: (saveDraftPolicyUrl: string, draftPolicy: Policy, cancellationToken: CancelToken) => Promise<void>,
     publishPolicy: (publishPolicyUrl: string, distributeAdaptationPolicyUrl: string, distributeNcfsPolicy: string, policyId: Guid) => Promise<void>,
-    deleteDraftPolicy: (deleteDraftPolicyUrl: string, policyId: Guid) => Promise<void>,
+    deleteDraftPolicy: (deleteDraftPolicyUrl: string, policyId: Guid, cancellationToken: CancelToken) => Promise<void>,
     getPolicyHistory: (getPolicyHistoryUrl: string, cancellationToken: CancelToken) => Promise<PolicyHistory>
 }

--- a/server/src/common/services/IPolicyManagementService.ts
+++ b/server/src/common/services/IPolicyManagementService.ts
@@ -1,5 +1,6 @@
 import { Guid } from "guid-typescript";
 import { Logger } from "winston";
+import { CancelToken } from "axios";
 import { GetPolicyByIdRequest } from "../models/PolicyManagementService/GetPolicyById/GetPolicyByIdRequest";
 import { Policy } from "../models/PolicyManagementService/Policy/Policy";
 import { PolicyHistory } from "../models/PolicyManagementService/PolicyHistory/PolicyHistory";
@@ -7,10 +8,10 @@ import { PolicyHistory } from "../models/PolicyManagementService/PolicyHistory/P
 export default interface IPolicyManagementService {
     logger: Logger,
     getPolicy: (request: GetPolicyByIdRequest) => Promise<Policy>,
-    getCurrentPolicy: (getCurrentPolicyUrl: string) => Promise<Policy>,
-    getDraftPolicy: (getDraftPolicyUrl: string) => Promise<Policy>,
+    getCurrentPolicy: (getCurrentPolicyUrl: string, cancellationToken: CancelToken) => Promise<Policy>,
+    getDraftPolicy: (getDraftPolicyUrl: string, cancellationToken: CancelToken) => Promise<Policy>,
     saveDraftPolicy: (saveDraftPolicyUrl: string, draftPolicy: Policy) => Promise<void>,
     publishPolicy: (publishPolicyUrl: string, distributeAdaptationPolicyUrl: string, distributeNcfsPolicy: string, policyId: Guid) => Promise<void>,
     deleteDraftPolicy: (deleteDraftPolicyUrl: string, policyId: Guid) => Promise<void>,
-    getPolicyHistory: (getPolicyHistoryUrl: string) => Promise<PolicyHistory>
+    getPolicyHistory: (getPolicyHistoryUrl: string, cancellationToken: CancelToken) => Promise<PolicyHistory>
 }

--- a/server/src/common/services/ITransactionEventService.ts
+++ b/server/src/common/services/ITransactionEventService.ts
@@ -1,9 +1,10 @@
 import { Logger } from "winston";
 import { GetTransactionsRequest, GetTransactionsResponse } from "../../common/models/TransactionEventService/GetTransactions";
 import { GetTransactionDetailsRequest, GetTransactionDetailsResponse } from "../../common/models/TransactionEventService/GetTransactionDetails";
+import { CancelToken } from "axios";
 
 export default interface ITransactionEventService {
     logger: Logger,
-    getTransactions: (request: GetTransactionsRequest) => Promise<GetTransactionsResponse>,
-    getTransactionDetails: (request: GetTransactionDetailsRequest) => Promise<GetTransactionDetailsResponse>
+    getTransactions: (request: GetTransactionsRequest, cancellationToken: CancelToken) => Promise<GetTransactionsResponse>,
+    getTransactionDetails: (request: GetTransactionDetailsRequest, cancellationToken: CancelToken) => Promise<GetTransactionDetailsResponse>
 }

--- a/server/src/service/Routes/Policy/PolicyRoutes.test.ts
+++ b/server/src/service/Routes/Policy/PolicyRoutes.test.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import bodyParser from "body-parser";
 import winston from "winston";
+import axios from "axios";
 import request from "supertest";
 import { SinonStub, stub } from "sinon";
 import { Guid } from "guid-typescript";
@@ -226,7 +227,7 @@ describe("PolicyRoutes", () => {
                     .expect(200, () => {
                         // Assert
                         expect(spy).toHaveBeenCalled();
-                        expect(spy).toBeCalledWith(expectedRequestUrl, policyExample);
+                        expect(spy).toBeCalledWith(expectedRequestUrl, policyExample, axios.CancelToken.source().token);
                         done();
                     })
             });
@@ -319,7 +320,7 @@ describe("PolicyRoutes", () => {
                     .expect(200, () => {
                         // Assert
                         expect(spy).toHaveBeenCalled();
-                        expect(spy).toBeCalledWith(expectedRequestUrl, policyId);
+                        expect(spy).toBeCalledWith(expectedRequestUrl, policyId, axios.CancelToken.source().token);
                         done();
                     })
             });

--- a/server/src/service/Routes/Policy/PolicyRoutes.ts
+++ b/server/src/service/Routes/Policy/PolicyRoutes.ts
@@ -51,17 +51,22 @@ class PolicyRoutes {
         this.app.get("/policy/getPolicy/:policyId", async (req, res) => {
             const requestUrl = this.policyManagementServiceBaseUrl + this.getPolicyPath;
 
+            const cancellationTokenSource = axios.CancelToken.source();
+            _handleCancellation(req, cancellationTokenSource);
+
             try {
                 const getPolicyRequest = new GetPolicyByIdRequest(requestUrl, Guid.parse(req.params.policyId));
 
-                const policy = await this.policyManagementService.getPolicy(getPolicyRequest);
+                const policy = await this.policyManagementService.getPolicy(getPolicyRequest, cancellationTokenSource.token);
 
                 res.json(policy);
             }
             catch (error) {
-                const message = "Error Retrieving Policy";
-                this.logger.error(message + error.stack);
-                res.status(500).json(message);
+                if (error.stack) {
+                    const message = "Error Retrieving Policy";
+                    this.logger.error(message + error.stack);
+                    res.status(500).json(message);
+                }
             }
         });
 
@@ -111,15 +116,20 @@ class PolicyRoutes {
         this.app.put("/policy/draft", async (req, res) => {
             const requestUrl = this.policyManagementServiceBaseUrl + this.saveDraftPolicyPath;
 
+            const cancellationTokenSource = axios.CancelToken.source();
+            _handleCancellation(req, cancellationTokenSource);
+
             try {
-                await this.policyManagementService.saveDraftPolicy(requestUrl, req.body);
+                await this.policyManagementService.saveDraftPolicy(requestUrl, req.body, cancellationTokenSource.token);
 
                 res.sendStatus(200);
             }
             catch (error) {
-                const message = "Error Updating the Draft Policy";
-                this.logger.error(message + error.stack);
-                res.status(500).json(message);
+                if (error.stack) {
+                    const message = "Error Updating the Draft Policy";
+                    this.logger.error(message + error.stack);
+                    res.status(500).json(message);
+                }
             }
         });
 
@@ -146,15 +156,21 @@ class PolicyRoutes {
         this.app.delete("/policy/draft/:policyId", async (req, res) => {
             const requestUrl = this.policyManagementServiceBaseUrl + this.deletePolicyPath;
 
+            const cancellationTokenSource = axios.CancelToken.source();
+            _handleCancellation(req, cancellationTokenSource);
+
             try {
-                await this.policyManagementService.deleteDraftPolicy(requestUrl, Guid.parse(req.params.policyId));
+                await this.policyManagementService.deleteDraftPolicy(
+                    requestUrl, Guid.parse(req.params.policyId), cancellationTokenSource.token);
 
                 res.sendStatus(200);
             }
             catch (error) {
-                const message = `Error Deleting Policy - PolicyId: ${req.params.policyId}`;
-                this.logger.error(message + error.stack);
-                res.status(500).json(message);
+                if (error.stack) {
+                    const message = `Error Deleting Policy - PolicyId: ${req.params.policyId}`;
+                    this.logger.error(message + error.stack);
+                    res.status(500).json(message);
+                }
             }
         });
 

--- a/server/src/service/Routes/RequestHistory/RequestHistoryRoutes.ts
+++ b/server/src/service/Routes/RequestHistory/RequestHistoryRoutes.ts
@@ -1,9 +1,16 @@
-import { Express } from "express";
+import { Express, Request } from "express";
 import { Logger } from "winston";
+import axios, { CancelTokenSource } from "axios";
 import TransactionEventService from "../../../business/services/TransactionEventService/TransactionEventService";
 import { GetTransactionsRequest } from "../../../common/models/TransactionEventService/GetTransactions";
 import { GetTransactionDetailsRequest } from "../../../common/models/TransactionEventService/GetTransactionDetails";
 import IConfig from "../../../common/models/IConfig";
+
+const _handleCancellation = (req: Request, cancellationTokenSource: CancelTokenSource) => {
+    req.connection.on("close", () => {
+        cancellationTokenSource.cancel("Request Cancelled by the Client");
+    });
+}
 
 class RequestHistoryRoutes {
     transactionEventServiceBaseUrl: string;
@@ -28,34 +35,46 @@ class RequestHistoryRoutes {
         this.app.post("/request-history/transactions", async (req, res) => {
             const requestUrl = this.transactionEventServiceBaseUrl + this.getTransactionsPath;
 
+            const cancellationTokenSource = axios.CancelToken.source();
+            _handleCancellation(req, cancellationTokenSource);
+
             try {
                 const transactionRequest = new GetTransactionsRequest(requestUrl, req.body);
 
-                const transactions = await this.transactionEventService.getTransactions(transactionRequest);
+                const transactions = await this.transactionEventService.getTransactions(
+                    transactionRequest, cancellationTokenSource.token);
 
                 res.json(transactions);
             }
             catch (error) {
-                const message = "Error Retrieving Transactions ";
-                this.logger.error(message + error.stack);
-                res.status(500).json(message);
+                if (error.stack) {
+                    const message = "Error Retrieving Transactions ";
+                    this.logger.error(message + error.stack);
+                    res.status(500).json(message);
+                }
             }
         });
 
         this.app.get("/request-history/transactionDetails/:transactionFilePath", async (req, res) => {
             const requestUrl = this.transactionEventServiceBaseUrl + this.getTransactionDetailsPath;
 
+            const cancellationTokenSource = axios.CancelToken.source();
+            _handleCancellation(req, cancellationTokenSource);
+
             try {
                 const transactionDetailsRequest = new GetTransactionDetailsRequest(requestUrl, req.params.transactionFilePath);
 
-                const transactionDetails = await this.transactionEventService.getTransactionDetails(transactionDetailsRequest);
+                const transactionDetails = await this.transactionEventService.getTransactionDetails(
+                    transactionDetailsRequest, cancellationTokenSource.token);
 
                 res.json(transactionDetails);
             }
             catch (error) {
-                const message = `Error Retrieving Transaction Details for file: ${req.params.transactionFilePath} `
-                this.logger.error(message + error.stack);
-                res.status(500).json(message);
+                if (error.stack) {
+                    const message = `Error Retrieving Transaction Details for file: ${req.params.transactionFilePath} `
+                    this.logger.error(message + error.stack);
+                    res.status(500).json(message);
+                }
             }
         });
     }

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -412,6 +412,13 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@types/axios@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@types/axios/-/axios-0.14.0.tgz#ec2300fbe7d7dddd7eb9d3abf87999964cafce46"
+  integrity sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=
+  dependencies:
+    axios "*"
+
 "@types/babel__core@^7.1.0":
   version "7.1.10"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.10.tgz#ca58fc195dd9734e77e57c6f2df565623636ab40"
@@ -822,6 +829,13 @@ aws4@^1.8.0:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.1.tgz#e1e82e4f3e999e2cfd61b161280d16a111f86428"
   integrity sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
+
+axios@*, axios@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.0.tgz#26df088803a2350dff2c27f96fef99fe49442aca"
+  integrity sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==
+  dependencies:
+    follow-redirects "^1.10.0"
 
 babel-jest@^24.9.0:
   version "24.9.0"
@@ -1823,6 +1837,11 @@ fn.name@1.x.x:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
+
+follow-redirects@^1.10.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
+  integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
- Installed Axios

## React
### frontend/src/context/policy/
- Updated /api methods to take a CancelToken as an argument, and pass it to the cancelToken field in axios requests
- Updated PolicyState: Creates an Axios CancelTokenSource and passes down to methods in ../api
- PolicyState calls the cancel method on the cancellationToken in the useEffect cleanup.

### frontend/src/views/RequestHistory/
- Updated /api methods to take a CancelToken as an argument, and pass it to the cancelToken field in axios requests
- Now has a CancelTokenSource initialised at the top of the component
- Updated useEffect to use pass a CancelToken to the api methods
- Updated /FileInfo component to include an extra prop for the CancelToken, and passes that to the api method for retrieving TransactionDetails
- Now calls the cancel method on the cancellationToken in the useEffect cleanup.

## Express
### RequestHistory
- Added axios cancellation tokens to RequestHistoryRoutes, passing them down to the TransactionEventService
- Added an on "connection close" express listener to call the cancel() method on the cancellation token when the connection is closed
- TransactionEventService passes the cancellation tokens to the TransactionEventApi
- TransactionEventApi now uses Axios to make the Http calls to the cluster's TransactionEventApi -passing the cancellation token to the axios method

### Policy
- Same as above for the RequestHistory routes
- Skipped the publish routes as cancelling one request in the chain would cause a mismatch of distributed/published policies