### PR TITLE
Prevent the User from Navigating Away if there are Unsaved Policy Changes

### DIFF
--- a/server/frontend/src/views/Policy/CurrentPolicy/CurrentPolicy.tsx
+++ b/server/frontend/src/views/Policy/CurrentPolicy/CurrentPolicy.tsx
@@ -13,6 +13,7 @@ import Tab from "../../../components/Tabs/Tab/Tab";
 import ContentManagementFlags from "../common/ContentManagementFlags/ContentManagementFlags";
 import RoutesForNonCompliantFiles from "../common/RoutesForNonCompliantFiles/RoutesForNonCompliantFiles";
 import PolicyForNonCompliantFiles from "../common/PolicyForNonCompliantFiles/PolicyForNonCompliantFiles";
+import UnsavedChangesPrompt from "../common/UnsavedChangesPrompt/UnsavedChangesPrompt";
 
 import { PolicyContext } from "../../../context/policy/PolicyContext";
 
@@ -20,6 +21,7 @@ import classes from "./CurrentPolicy.module.scss";
 
 const CurrentPolicy = () => {
 	const {
+		isPolicyChanged,
 		currentPolicy,
 		status
 	} = useContext(PolicyContext);
@@ -67,55 +69,61 @@ const CurrentPolicy = () => {
 			}
 
 			{status === "LOADED" &&
-				<TabNav
-					tabs={tabs}
-					selectedTabName={selectedTab}
-					onSetActiveTabHandler={(tab) => setSelectedTab(tab)}>
+				<>
+					<UnsavedChangesPrompt
+                        when={isPolicyChanged}
+                        message="You have unsaved changes in the draft tab, are you sure you want to leave the page?" />
+				
+					<TabNav
+						tabs={tabs}
+						selectedTabName={selectedTab}
+						onSetActiveTabHandler={(tab) => setSelectedTab(tab)}>
 
-					<div className={classes.innerContent}>
-						<Tab isSelected={selectedTab === "Adaptation Policy"} externalStyles={classes.Tab}>
-							<h2 className={classes.head}>Content Management Flags</h2>
-							{policyTimestampData}
-							<ContentManagementFlags
-								contentManagementFlags={currentPolicy.adaptionPolicy.contentManagementFlags}
-								disabled />
-						</Tab>
-
-						<Tab isSelected={selectedTab === "NCFS Policy"} externalStyles={classes.Tab}>
-							<>
-								<h2 className={classes.head}>Config for non-compliant files</h2>
+						<div className={classes.innerContent}>
+							<Tab isSelected={selectedTab === "Adaptation Policy"} externalStyles={classes.Tab}>
+								<h2 className={classes.head}>Content Management Flags</h2>
 								{policyTimestampData}
-								<div className={classes.ncfsContainer}>
-									<section className={classes.info}>
-										<div>
-											<h3>
-												<strong>Un-Processable File Types</strong>{" "}
-											</h3>
-											<p>
-												When the filetype of the original file is identified as one that
-												the Glasswall SDK cannot rebuild.
-													</p>
-										</div>
-										<div>
-											<h3>
-												<strong>Glasswall Blocked Files</strong>
-											</h3>
-											<p>The original file cannot be rebuilt by the Glasswall SDK</p>
-										</div>
-									</section>
-									<RoutesForNonCompliantFiles
-										ncfsRoutingUrl={currentPolicy.adaptionPolicy.ncfsRoute ?
-											currentPolicy.adaptionPolicy.ncfsRoute.ncfsRoutingUrl : ""}
-										disabled />
+								<ContentManagementFlags
+									contentManagementFlags={currentPolicy.adaptionPolicy.contentManagementFlags}
+									disabled />
+							</Tab>
 
-									<PolicyForNonCompliantFiles
-										ncfsActions={currentPolicy.adaptionPolicy.ncfsActions}
-										disabled />
-								</div>
-							</>
-						</Tab>
-					</div>
-				</TabNav>
+							<Tab isSelected={selectedTab === "NCFS Policy"} externalStyles={classes.Tab}>
+								<>
+									<h2 className={classes.head}>Config for non-compliant files</h2>
+									{policyTimestampData}
+									<div className={classes.ncfsContainer}>
+										<section className={classes.info}>
+											<div>
+												<h3>
+													<strong>Un-Processable File Types</strong>{" "}
+												</h3>
+												<p>
+													When the filetype of the original file is identified as one that
+													the Glasswall SDK cannot rebuild.
+													</p>
+											</div>
+											<div>
+												<h3>
+													<strong>Glasswall Blocked Files</strong>
+												</h3>
+												<p>The original file cannot be rebuilt by the Glasswall SDK</p>
+											</div>
+										</section>
+										<RoutesForNonCompliantFiles
+											ncfsRoutingUrl={currentPolicy.adaptionPolicy.ncfsRoute ?
+												currentPolicy.adaptionPolicy.ncfsRoute.ncfsRoutingUrl : ""}
+											disabled />
+
+										<PolicyForNonCompliantFiles
+											ncfsActions={currentPolicy.adaptionPolicy.ncfsActions}
+											disabled />
+									</div>
+								</>
+							</Tab>
+						</div>
+					</TabNav>
+				</>
 			}
 		</div>
 	);

--- a/server/frontend/src/views/Policy/DraftPolicy/DraftPolicy.tsx
+++ b/server/frontend/src/views/Policy/DraftPolicy/DraftPolicy.tsx
@@ -13,6 +13,7 @@ import Modal from "../../../components/UI/Modal/Modal";
 import Backdrop from "../../../components/UI/Backdrop/Backdrop";
 import ConfirmDraftPublishModal from "./ConfirmDraftPublishModal/ConfirmDraftPublishModal";
 import ConfirmDraftDeleteModal from "./ConfirmDraftDeleteModal/ConfirmDraftDeleteModal";
+import UnsavedChangesPrompt from "../common/UnsavedChangesPrompt/UnsavedChangesPrompt";
 
 import classes from "./DraftPolicy.module.scss";
 
@@ -137,6 +138,10 @@ const DraftPolicy = () => {
 
             {status === "LOADED" &&
                 <>
+                    <UnsavedChangesPrompt
+                        when={isPolicyChanged}
+                        message="You have unsaved changes, are you sure you want to leave the page?" />
+
                     <TabNav
                         tabs={tabs}
                         selectedTabName={selectedTab}

--- a/server/frontend/src/views/Policy/History/History.tsx
+++ b/server/frontend/src/views/Policy/History/History.tsx
@@ -14,6 +14,7 @@ import HistoryRow from "./HistoryRow/HistoryRow";
 import Modal from "../../../components/UI/Modal/Modal";
 import HistoryInfo from "./HistoryInfo/HistoryInfo";
 import ConfirmPublishModal from "./ConfirmPublishModal/ConfirmPublishModal";
+import UnsavedChangesPrompt from "../common/UnsavedChangesPrompt/UnsavedChangesPrompt";
 
 import { PolicyContext } from "../../../context/policy/PolicyContext";
 
@@ -25,6 +26,7 @@ const History = () => {
 	const cancellationTokenSource = CancelToken.source();
 
 	const {
+		isPolicyChanged,
 		status,
 		policyHistory,
 		loadPolicyHistory
@@ -71,6 +73,10 @@ const History = () => {
 
 			{status === "LOADED" && policyHistory !== null &&
 				<>
+					<UnsavedChangesPrompt
+						when={isPolicyChanged}
+						message="You have unsaved changes in the draft tab, are you sure you want to leave the page?" />
+
 					<div className={classes.History}>
 						<div className={classes.container}>
 							<Table className={classes.table}>

--- a/server/frontend/src/views/Policy/common/UnsavedChangesPrompt/UnsavedChangesPrompt.tsx
+++ b/server/frontend/src/views/Policy/common/UnsavedChangesPrompt/UnsavedChangesPrompt.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Prompt } from "react-router-dom";
+
+export interface UnsavedChangesPromptProps {
+    when: boolean,
+    message: string
+}
+
+const UnsavedChangesPrompt = (props: UnsavedChangesPromptProps) => {
+    return (
+        <Prompt when={props.when} message={props.message} />
+    );
+};
+
+export default UnsavedChangesPrompt;


### PR DESCRIPTION
- Added a new component: UnsavedChangesPrompt to /frontend/views/policy
- If isPolicyChanged from the PolicyContext is set to true, the prompt will activate when the user tries to leave the page
- The prompt is a vanilla window.confirm message, clicking "ok" should take the user to the next page, clicking cancel will make sure they remain on the policy page