### PR TITLE
Handle 204 Response from GET-/policy/history in Policy Management Api

### DIFF
--- a/server/frontend/src/context/policy/PolicyState.tsx
+++ b/server/frontend/src/context/policy/PolicyState.tsx
@@ -156,9 +156,11 @@ export const PolicyState = (props: { children: React.ReactNode }) => {
 		(async (): Promise<void> => {
 			try {
 				const policyHistory = await getPolicyHistory(cancellationToken);
-				policyHistory.policies.sort((a: any, b: any) => {
-					return Date.parse(b.created) - Date.parse(a.created);
-				});
+				if (policyHistory.policiesCount) {
+					policyHistory.policies.sort((a: any, b: any) => {
+						return Date.parse(b.created) - Date.parse(a.created);
+					});
+				}
 				setPolicyHistory(policyHistory);
 
 				status = "LOADED";

--- a/server/frontend/src/context/policy/api/helpers/getPolicy.ts
+++ b/server/frontend/src/context/policy/api/helpers/getPolicy.ts
@@ -11,7 +11,7 @@ export const getPolicy = async (baseUrl: string, cancellationToken: CancelToken)
         cancelToken: cancellationToken
     });
 
-    if (response.statusText !== "OK") {
+    if (response.status < 200 || response.status > 299) {
         throw response.statusText;
     }
 

--- a/server/frontend/src/context/policy/api/helpers/getPolicyById.ts
+++ b/server/frontend/src/context/policy/api/helpers/getPolicyById.ts
@@ -14,7 +14,7 @@ export const getPolicyById = async (baseUrl: string, policyId: Guid, cancellatio
         cancelToken: cancellationToken
     });
 
-    if (response.statusText !== "OK") {
+    if (response.status < 200 || response.status > 299) {
         throw response.statusText;
     }
 

--- a/server/frontend/src/context/policy/api/index.ts
+++ b/server/frontend/src/context/policy/api/index.ts
@@ -28,7 +28,7 @@ export const saveDraftPolicy = async (policy: Policy, cancellationToken: CancelT
         cancelToken: cancellationToken
     });
 
-    if (response.statusText !== "OK") {
+    if (response.status < 200 || response.status > 299) {
         throw response.statusText;
     }
 }
@@ -45,7 +45,7 @@ export const publishPolicy = async (policyId: Guid, cancellationToken: CancelTok
         cancelToken: cancellationToken
     });
 
-    if (response.statusText !== "OK") {
+    if (response.status < 200 || response.status > 299) {
         throw response.statusText;
     }
 }
@@ -62,7 +62,7 @@ export const deleteDraftPolicy = async (policyId: Guid, cancellationToken: Cance
         cancelToken: cancellationToken
     });
 
-    if (response.statusText !== "OK") {
+    if (response.status < 200 || response.status > 299) {
         throw response.statusText;
     }
 }
@@ -79,7 +79,7 @@ export const getPolicyHistory = async (cancellationToken: CancelToken): Promise<
         cancelToken: cancellationToken
     });
 
-    if (response.statusText !== "OK") {
+    if (response.status < 200 || response.status > 299) {
         throw response.statusText;
     }
 

--- a/server/frontend/src/context/policy/policy-reducers.ts
+++ b/server/frontend/src/context/policy/policy-reducers.ts
@@ -11,7 +11,9 @@ const setIsPolicyChanged = (state: TPolicyState, changed: boolean) => {
 	});
 };
 
-const setPolicyError = (state: TPolicyState, error: string) => {
+const setPolicyError = (state: TPolicyState, error: any) => {
+	console.error(error);
+
 	return updateObject(state, {
 		policyError: error
 	});

--- a/server/frontend/src/views/Policy/History/History.tsx
+++ b/server/frontend/src/views/Policy/History/History.tsx
@@ -20,6 +20,7 @@ import { PolicyContext } from "../../../context/policy/PolicyContext";
 
 import classes from "./History.module.scss";
 import { PolicyType } from "../../../../../src/common/models/enums/PolicyType";
+import EmptyHistoryRow from "./HistoryRow/EmptyHistoryRow";
 
 const History = () => {
 	const CancelToken = axios.CancelToken;
@@ -49,9 +50,7 @@ const History = () => {
 	};
 
 	useEffect(() => {
-		if (status !== "ERROR") {
-			loadPolicyHistory(cancellationTokenSource.token);
-		}
+		loadPolicyHistory(cancellationTokenSource.token);
 
 		return () => {
 			cancellationTokenSource.cancel();
@@ -87,19 +86,27 @@ const History = () => {
 									</TableRow>
 								</TableHead>
 								<TableBody className={classes.tbody}>
-									{policyHistory.policies.map((policy: Policy) => {
-										return (
-											<HistoryRow
-												key={policy.id}
-												id={policy.id}
-												isCurrent={policy.policyType === PolicyType.Current}
-												openPreviousPolicyModalHandler={() => openPolicyModal(policy.id)}
-												activatePreviousPolicyHandler={() => openConfirmPublishModal(policy.id)}
-												timestamp={new Date(policy.created).toLocaleString()}
-												updatedBy={policy.updatedBy ? policy.updatedBy : "N/A"}
-											/>
-										)
-									})}
+									{policyHistory.policiesCount > 0 &&
+										<>
+											{policyHistory.policies.map((policy: Policy) => {
+												return (
+													<HistoryRow
+														key={policy.id}
+														id={policy.id}
+														isCurrent={policy.policyType === PolicyType.Current}
+														openPreviousPolicyModalHandler={() => openPolicyModal(policy.id)}
+														activatePreviousPolicyHandler={() => openConfirmPublishModal(policy.id)}
+														timestamp={new Date(policy.created).toLocaleString()}
+														updatedBy={policy.updatedBy ? policy.updatedBy : "N/A"}
+													/>
+												)
+											})}
+										</>
+									}
+
+									{!policyHistory.policies &&
+										<EmptyHistoryRow />
+									}
 								</TableBody>
 							</Table>
 						</div>

--- a/server/frontend/src/views/Policy/History/HistoryRow/EmptyHistoryRow.tsx
+++ b/server/frontend/src/views/Policy/History/HistoryRow/EmptyHistoryRow.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { TableRow, TableCell } from "@material-ui/core";
+
+import classes from "./HistoryRow.module.scss";
+
+const EmptyHistoryRow = () => {
+    return (
+        <TableRow className={classes.HistoryRow}>
+            <TableCell colSpan={4} component="th" scope="row">
+                No Previous Policies Were Found.
+            </TableCell>
+        </TableRow>
+    );
+};
+
+export default EmptyHistoryRow;


### PR DESCRIPTION
- Updated PolicyState to handle a 204 status code
- Updated History component to show an empty row rather than nothing when there are no previous policies
- Updated PolicyState to log errors properly