### PR TITLE
FIX - While current policy page is loading, navigating to history page, and back to current page results in white screen

### DIFF
--- a/server/frontend/src/context/policy/PolicyContext.tsx
+++ b/server/frontend/src/context/policy/PolicyContext.tsx
@@ -1,4 +1,3 @@
-import { CancelToken } from "axios";
 import { Guid } from "guid-typescript";
 import { createContext } from "react";
 import { Policy } from "../../../../src/common/models/PolicyManagementService/Policy/Policy";
@@ -13,7 +12,6 @@ export type TPolicyState = {
 	cancelDraftChanges: () => void,
 	publishPolicy: (policyId: Guid) => void,
 	deleteDraftPolicy: (policyId: Guid) => void,
-	loadPolicyHistory: (cancellationToken: CancelToken) => void,
 	policyHistory: PolicyHistory,
 	isPolicyChanged: boolean,
 	status: "LOADING" | "ERROR" | "LOADED",

--- a/server/frontend/src/context/policy/PolicyState.tsx
+++ b/server/frontend/src/context/policy/PolicyState.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useReducer } from "react";
-import axios, { CancelToken } from "axios";
+import axios from "axios";
 import { Guid } from "guid-typescript";
 import { PolicyContext } from "./PolicyContext";
 import { policyReducer } from "./policy-reducers";
@@ -64,10 +64,25 @@ export const PolicyState = (props: { children: React.ReactNode }) => {
 		dispatch({ type: actionTypes.SET_POLICY_HISTORY, policyHistory });
 	}
 
-
-
 	const setNewDraftPolicy = (policy: Policy) => {
 		dispatch({ type: actionTypes.SET_NEW_DRAFT_POLICY, newPolicy: policy });
+	}
+
+	const _loadPolicies = async () => {
+		const currentPolicy = await getCurrentPolicy(cancellationTokenSource.token);
+		setCurrentPolicy(currentPolicy);
+
+		const draftPolicy = await getDraftPolicy(cancellationTokenSource.token);
+		setDraftPolicy(draftPolicy);
+		setNewDraftPolicy(draftPolicy);
+
+		const policyHistory = await getPolicyHistory(cancellationTokenSource.token);
+		if (policyHistory.policiesCount) {
+			policyHistory.policies.sort((a: any, b: any) => {
+				return Date.parse(b.created) - Date.parse(a.created);
+			});
+		}
+		setPolicyHistory(policyHistory);
 	}
 
 	const saveDraftChanges = () => {
@@ -103,12 +118,7 @@ export const PolicyState = (props: { children: React.ReactNode }) => {
 			try {
 				await publish(policyId, cancellationTokenSource.token);
 
-				const currentPolicy = await getCurrentPolicy(cancellationTokenSource.token);
-				setCurrentPolicy(currentPolicy);
-
-				const draftPolicy = await getDraftPolicy(cancellationTokenSource.token);
-				setDraftPolicy(draftPolicy);
-				setNewDraftPolicy(draftPolicy);
+				await _loadPolicies();
 
 				status = "LOADED";
 			}
@@ -130,47 +140,11 @@ export const PolicyState = (props: { children: React.ReactNode }) => {
 			try {
 				await deleteDraft(policyId, cancellationTokenSource.token);
 
-				const currentPolicy = await getCurrentPolicy(cancellationTokenSource.token);
-				setCurrentPolicy(currentPolicy);
-
-				const draftPolicy = await getDraftPolicy(cancellationTokenSource.token);
-				setDraftPolicy(draftPolicy);
-				setNewDraftPolicy(draftPolicy);
+				await _loadPolicies();
 
 				status = "LOADED";
 			}
 			catch (error) {
-				setPolicyError(error);
-				status = "ERROR";
-			}
-			finally {
-				setStatus(status);
-			}
-		})();
-	}
-
-	const loadPolicyHistory = (cancellationToken: CancelToken) => {
-		let status: "LOADING" | "ERROR" | "LOADED" = "LOADING";
-		setStatus(status);
-
-		(async (): Promise<void> => {
-			try {
-				const policyHistory = await getPolicyHistory(cancellationToken);
-				if (policyHistory.policiesCount) {
-					policyHistory.policies.sort((a: any, b: any) => {
-						return Date.parse(b.created) - Date.parse(a.created);
-					});
-				}
-				setPolicyHistory(policyHistory);
-
-				status = "LOADED";
-			}
-			catch (error) {
-				if (axios.isCancel(error)) {
-					status = "LOADED";
-					return;
-				}
-
 				setPolicyError(error);
 				status = "ERROR";
 			}
@@ -186,12 +160,7 @@ export const PolicyState = (props: { children: React.ReactNode }) => {
 
 		(async (): Promise<void> => {
 			try {
-				const currentPolicy = await getCurrentPolicy(cancellationTokenSource.token);
-				setCurrentPolicy(currentPolicy);
-
-				const draftPolicy = await getDraftPolicy(cancellationTokenSource.token);
-				setDraftPolicy(draftPolicy);
-				setNewDraftPolicy(draftPolicy);
+				await _loadPolicies();
 
 				status = "LOADED";
 			}
@@ -223,7 +192,6 @@ export const PolicyState = (props: { children: React.ReactNode }) => {
 			cancelDraftChanges,
 			publishPolicy,
 			deleteDraftPolicy,
-			loadPolicyHistory,
 			policyHistory: policyState.policyHistory,
 			isPolicyChanged: policyState.isPolicyChanged,
 			status: policyState.status,

--- a/server/frontend/src/views/Policy/CurrentPolicy/CurrentPolicy.tsx
+++ b/server/frontend/src/views/Policy/CurrentPolicy/CurrentPolicy.tsx
@@ -33,30 +33,33 @@ const CurrentPolicy = () => {
 		{ testId: "buttonCurrentNcfsPolicyTab", name: "NCFS Policy" },
 	];
 
-	const policyTimestampData = (
-		<div className={classes.tableContainer}>
-			{status === "LOADED" &&
-				<Table className={classes.table} id={currentPolicy.id}>
-					<TableHead>
-						<TableRow>
-							<TableCell>Timestamp</TableCell>
-							<TableCell>Updated By</TableCell>
-						</TableRow>
-					</TableHead>
-					<TableBody className={classes.tbody}>
-						<TableRow>
-							<TableCell>
-								{new Date(currentPolicy.created).toLocaleString()}
-							</TableCell>
-							<TableCell>
-								{currentPolicy.updatedBy ? currentPolicy.updatedBy : "N/A"}
-							</TableCell>
-						</TableRow>
-					</TableBody>
-				</Table>
-			}
-		</div>
-	);
+	let policyTimestampData: any = null;
+	if (currentPolicy) {
+		policyTimestampData = (
+			<div className={classes.tableContainer}>
+				{status === "LOADED" &&
+					<Table className={classes.table} id={currentPolicy.id}>
+						<TableHead>
+							<TableRow>
+								<TableCell>Timestamp</TableCell>
+								<TableCell>Updated By</TableCell>
+							</TableRow>
+						</TableHead>
+						<TableBody className={classes.tbody}>
+							<TableRow>
+								<TableCell>
+									{new Date(currentPolicy.created).toLocaleString()}
+								</TableCell>
+								<TableCell>
+									{currentPolicy.updatedBy ? currentPolicy.updatedBy : "N/A"}
+								</TableCell>
+							</TableRow>
+						</TableBody>
+					</Table>
+				}
+			</div>
+		);
+	}
 
 	return (
 		<div className={classes.Current}>
@@ -71,9 +74,9 @@ const CurrentPolicy = () => {
 			{status === "LOADED" &&
 				<>
 					<UnsavedChangesPrompt
-                        when={isPolicyChanged}
-                        message="You have unsaved changes in the draft tab, are you sure you want to leave the page?" />
-				
+						when={isPolicyChanged}
+						message="You have unsaved changes in the draft tab, are you sure you want to leave the page?" />
+
 					<TabNav
 						tabs={tabs}
 						selectedTabName={selectedTab}

--- a/server/frontend/src/views/Policy/History/History.tsx
+++ b/server/frontend/src/views/Policy/History/History.tsx
@@ -1,5 +1,4 @@
-import React, { useContext, useState, useEffect } from "react";
-import axios from "axios";
+import React, { useContext, useState } from "react";
 import { CSSTransition } from "react-transition-group";
 import {
 	Table,
@@ -23,14 +22,10 @@ import { PolicyType } from "../../../../../src/common/models/enums/PolicyType";
 import EmptyHistoryRow from "./HistoryRow/EmptyHistoryRow";
 
 const History = () => {
-	const CancelToken = axios.CancelToken;
-	const cancellationTokenSource = CancelToken.source();
-
 	const {
 		isPolicyChanged,
 		status,
 		policyHistory,
-		loadPolicyHistory
 	} = useContext(PolicyContext);
 
 	const [showPolicyModal, setShowPolicyModal] = useState(false);
@@ -48,15 +43,6 @@ const History = () => {
 			policyHistory.policies.find(policy => policy.id === policyId));
 		setShowConfirmPublishModal(true);
 	};
-
-	useEffect(() => {
-		loadPolicyHistory(cancellationTokenSource.token);
-
-		return () => {
-			cancellationTokenSource.cancel();
-		}
-		// eslint-disable-next-line
-	}, []);
 
 	return (
 		<>


### PR DESCRIPTION
fixes #127
fixes #120 

Moved the call for loading the policy history into PolicyState. This removes the issue as switching between the history and draft/current tabs will no longer call the cancel method on the cancellation token.