### PR TITLE
FIX - UI Bug: The Risk for unknown files are not displayed

### DIFF
--- a/server/src/common/models/enums/Risk.ts
+++ b/server/src/common/models/enums/Risk.ts
@@ -1,4 +1,5 @@
 export enum Risk {
+    "Unknown" = -1,
     "Blocked by Policy" = 0,
     "Blocked by NCFS" = 1,
     "Allowed by Policy" = 2,


### PR DESCRIPTION
Fixed by adding the 'Unknown' risk type.

Seb: "If the API is returning Unknown, it may be because the adaptation process is not calling the NCFS service yet, so if that was being used it'd probably be either 'Allowed By NCFS' or 'Blocked by NCFS'."