### PR TITLE
FIX - UI Analytics-- The Analytics View is blank for a period with no transactions

### DIFF
--- a/server/frontend/src/views/Analytics/Analytics.jsx
+++ b/server/frontend/src/views/Analytics/Analytics.jsx
@@ -68,7 +68,9 @@ const Analytics = ({ data }) => {
                             */}
                     </div>
                     <div data-test-id="lineChart" className={classes.lineChart}>
-                        <LineChart data={data} />
+                        {data.totalProcessed > 0 &&
+                            <LineChart data={data} />
+                        }
                     </div>
                 </div>
             </article>

--- a/server/frontend/src/views/Analytics/AnalyticsWrapper.tsx
+++ b/server/frontend/src/views/Analytics/AnalyticsWrapper.tsx
@@ -62,12 +62,8 @@ const AnalyticsWrapper = () => {
                     <div>Loading...</div>
                 }
 
-                {status === "LOADED" && data.totalProcessed > 0 &&
+                {status === "LOADED" &&
                     <Analytics data={data} />
-                }
-
-                {status === "LOADED" && data.totalProcessed < 1 &&
-                    <div>No Metrics Found</div>
                 }
 
                 {status === "ERROR" &&


### PR DESCRIPTION
@NadHodeGW 
When encountering a period with no files:
- The 'Total Files Processed' counter should now appear with a value of 0.
- Should still be able to select the date/time on the filter.