### PR TITLE
Fix - UI - Main: Unable to view Current policy screen

### DIFF
--- a/server/frontend/src/views/Policy/CurrentPolicy/CurrentPolicy.tsx
+++ b/server/frontend/src/views/Policy/CurrentPolicy/CurrentPolicy.tsx
@@ -123,9 +123,10 @@ const CurrentPolicy = () => {
 											{ncfsActionsDescriptions}
 										</section>
 										<RoutesForNonCompliantFiles
-											ncfsRoutingUrl={currentPolicy.adaptionPolicy.ncfsRoute ?
+											ncfsRoutingUrl={currentPolicy.adaptionPolicy.ncfsRoute !== null ?
 												currentPolicy.adaptionPolicy.ncfsRoute.ncfsRoutingUrl : ""}
-											currentPolicyRoutingUrl={currentPolicy.adaptionPolicy.ncfsRoute.ncfsRoutingUrl}
+											currentPolicyRoutingUrl={currentPolicy.adaptionPolicy.ncfsRoute !== null ?
+												currentPolicy.adaptionPolicy.ncfsRoute.ncfsRoutingUrl : ""}
 											disabled />
 
 										<PolicyForNonCompliantFiles

--- a/server/frontend/src/views/Policy/DraftPolicy/DraftPolicy.tsx
+++ b/server/frontend/src/views/Policy/DraftPolicy/DraftPolicy.tsx
@@ -19,7 +19,7 @@ import UnsavedChangesPrompt from "../common/UnsavedChangesPrompt/UnsavedChangesP
 
 import classes from "./DraftPolicy.module.scss";
 
-const returnNcfsRoutingUrl = (ncfsRoutes: NcfsRoute) => ncfsRoutes ? ncfsRoutes.ncfsRoutingUrl : null;
+const returnNcfsRoutingUrl = (ncfsRoutes: NcfsRoute) => ncfsRoutes !== null ? ncfsRoutes.ncfsRoutingUrl : "";
 
 const DraftPolicy = () => {
 	const {

--- a/server/frontend/src/views/Policy/History/HistoryInfo/HistoryInfo.tsx
+++ b/server/frontend/src/views/Policy/History/HistoryInfo/HistoryInfo.tsx
@@ -72,8 +72,8 @@ const HistoryInfo = (props: HistoryInfoProps) => {
 							<h2 className={classes.head}>Config for non-compliant files</h2>
 							<div className={classes.ncfsContainer}>
 								<RoutesForNonCompliantFiles
-									ncfsRoutingUrl={props.policy.adaptionPolicy.ncfsRoute ? props.policy.adaptionPolicy.ncfsRoute.ncfsRoutingUrl : ""}
-									currentPolicyRoutingUrl={props.policy.adaptionPolicy.ncfsRoute ? props.policy.adaptionPolicy.ncfsRoute.ncfsRoutingUrl : ""}
+									ncfsRoutingUrl={props.policy.adaptionPolicy.ncfsRoute !== null ? props.policy.adaptionPolicy.ncfsRoute.ncfsRoutingUrl : ""}
+									currentPolicyRoutingUrl={props.policy.adaptionPolicy.ncfsRoute !== null ? props.policy.adaptionPolicy.ncfsRoute.ncfsRoutingUrl : ""}
 									disabled />
 
 								<PolicyForNonCompliantFiles

--- a/server/frontend/src/views/RequestHistory/FileInfo/ActivePolicy/ActiveNcfsPolicy.tsx
+++ b/server/frontend/src/views/RequestHistory/FileInfo/ActivePolicy/ActiveNcfsPolicy.tsx
@@ -6,24 +6,25 @@ import { AdaptionPolicy } from "../../../../../../src/common/models/PolicyManage
 
 
 export interface ActiveAdaptationPolicyProps {
-    adaptationPolicy: AdaptionPolicy
+	adaptationPolicy: AdaptionPolicy
 }
 
 const ActiveNcfsPolicy = (props: ActiveAdaptationPolicyProps) => {
-    return (
-        <>
-            <RoutesForNonCompliantFiles
-                ncfsRoutingUrl={props.adaptationPolicy.ncfsRoute ?
-                    props.adaptationPolicy.ncfsRoute.ncfsRoutingUrl : ""}
-                currentPolicyRoutingUrl={props.adaptationPolicy.ncfsRoute.ncfsRoutingUrl}
-                disabled />
+	return (
+		<>
+			<RoutesForNonCompliantFiles
+				ncfsRoutingUrl={props.adaptationPolicy.ncfsRoute !== null ?
+					props.adaptationPolicy.ncfsRoute.ncfsRoutingUrl : ""}
+				currentPolicyRoutingUrl={props.adaptationPolicy.ncfsRoute.ncfsRoutingUrl !== null ?
+					props.adaptationPolicy.ncfsRoute.ncfsRoutingUrl : ""}
+				disabled />
 
-            <PolicyForNonCompliantFiles
-                ncfsActions={props.adaptationPolicy.ncfsActions}
-                currentNcfsActions={props.adaptationPolicy.ncfsActions}
-                disabled />
-        </>
-    );
+			<PolicyForNonCompliantFiles
+				ncfsActions={props.adaptationPolicy.ncfsActions}
+				currentNcfsActions={props.adaptationPolicy.ncfsActions}
+				disabled />
+		</>
+	);
 }
 
 export default ActiveNcfsPolicy;

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "main": "dist/index.js",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "scripts": {
     "prebuild": "tslint -c tslint.json -p tsconfig.json --fix",
     "build": "tsc",


### PR DESCRIPTION
Updated null checks on the Policy's property
`{
  adaptionPolicy: {
    ncfsRoute: {ncfsRoutingUrl: ""}
  }
}`

ncfsRoute is null, so the ncfsRoutingUrl property doesn't exist.