### PR TITLE
FIX - UI: Opening the details view for file type COFF returns a blank page

### DIFF
--- a/server/frontend/src/views/RequestHistory/FileInfo/FileInfo.module.scss
+++ b/server/frontend/src/views/RequestHistory/FileInfo/FileInfo.module.scss
@@ -57,6 +57,17 @@
 			min-height: 13rem;
 		}
 
+		& .emptyAnalysisReport {
+			min-height: 4rem;
+			position: relative;
+
+			margin-bottom: 1.5rem;
+			padding: 1rem;
+			padding-left: 2.6rem;
+
+			overflow: hidden;
+		}
+
 		& .block {
 			min-height: 4rem;
 			position: relative;

--- a/server/frontend/src/views/RequestHistory/FileInfo/TransactionDetails/TransactionDetails.tsx
+++ b/server/frontend/src/views/RequestHistory/FileInfo/TransactionDetails/TransactionDetails.tsx
@@ -42,38 +42,48 @@ const TransactionDetails = (props: TransactionDetailsProps) => {
 	const clsBlockExpandend = [classes.block];
 
 	useEffect(() => {
-		props.analysisReport.documentStatistics.contentGroups.contentGroup.forEach((content: any) => {
-			if (content.issueItems.itemCount > 0) {
-				setIssueItems((prev: any) => {
-					return {
-						itemCount: prev.itemCount + content.issueItems.itemCount,
-						issues: prev.issues.concat(content.issueItems.issueItem)
-					};
-				});
-			}
+		if (props.analysisReport.documentStatistics.contentGroups.contentGroup !== null) {
 
-			if (content.remedyItems.itemCount > 0) {
-				setRemedyItems((prev: any) => {
-					return {
-						itemCount: prev.itemCount + content.remedyItems.itemCount,
-						remedies: prev.remedies.concat(content.remedyItems.remedyItem)
-					};
-				});
-			}
+			props.analysisReport.documentStatistics.contentGroups.contentGroup.forEach((content: any) => {
+				if (content.issueItems.itemCount > 0) {
+					setIssueItems((prev: any) => {
+						return {
+							itemCount: prev.itemCount + content.issueItems.itemCount,
+							issues: prev.issues.concat(content.issueItems.issueItem)
+						};
+					});
+				}
 
-			if (content.sanitisationItems.itemCount > 0) {
-				setSanitisationItems((prev: any) => {
-					return {
-						itemCount: prev.itemCount + content.sanitisationItems.itemCount,
-						sanitisations: prev.sanitisations.concat(content.sanitisationItems.sanitisationItem)
-					};
-				});
-			}
-		});
+				if (content.remedyItems.itemCount > 0) {
+					setRemedyItems((prev: any) => {
+						return {
+							itemCount: prev.itemCount + content.remedyItems.itemCount,
+							remedies: prev.remedies.concat(content.remedyItems.remedyItem)
+						};
+					});
+				}
+
+				if (content.sanitisationItems.itemCount > 0) {
+					setSanitisationItems((prev: any) => {
+						return {
+							itemCount: prev.itemCount + content.sanitisationItems.itemCount,
+							sanitisations: prev.sanitisations.concat(content.sanitisationItems.sanitisationItem)
+						};
+					});
+				}
+			});
+
+		}
 	}, [props]);
 
 	return (
 		<>
+			{issueItems.itemCount === 0 && remedyItems.itemCount === 0 && sanitisationItems.itemCount === 0 &&
+				<div>
+					Analysis Report was empty.
+				</div>
+			}
+
 			{issueItems.itemCount > 0 &&
 				<div className={clsBlockExpandend.join(" ")}>
 					Issue Items

--- a/server/frontend/src/views/RequestHistory/FileInfo/TransactionDetails/TransactionDetails.tsx
+++ b/server/frontend/src/views/RequestHistory/FileInfo/TransactionDetails/TransactionDetails.tsx
@@ -79,8 +79,8 @@ const TransactionDetails = (props: TransactionDetailsProps) => {
 	return (
 		<>
 			{issueItems.itemCount === 0 && remedyItems.itemCount === 0 && sanitisationItems.itemCount === 0 &&
-				<div>
-					Analysis Report was empty.
+				<div className={classes.emptyAnalysisReport}>
+					The Analysis Report for this file is empty.
 				</div>
 			}
 


### PR DESCRIPTION
Opening the file details modal for a file in the transaction log that had an empty analysis report was throwing an uncaught error. Added a check and a message displaying the analysis report was empty.